### PR TITLE
prettyProtocols should come after enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -55,8 +55,8 @@ prettySwiftDataWith indent = \case
     ++ prettyMoatType aliasTyp
 
   MoatNewtype{..} -> ""
-    ++ prettyProtocols newtypeProtocols
     ++ "enum "
+    ++ prettyProtocols newtypeProtocols
     ++ prettyMoatTypeHeader newtypeName newtypeTyVars
     ++ " {\n"
     ++ indents


### PR DESCRIPTION
Very minor bug where we were generating types and the `enum ` came after the protocols. Also, adding `dist-newstyle` to `.gitignore` for convenience