### PR TITLE
Swift `enum` in the wrong order

### DIFF
--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -55,9 +55,9 @@ prettySwiftDataWith indent = \case
     ++ prettyMoatType aliasTyp
 
   MoatNewtype{..} -> ""
-    ++ prettyProtocols newtypeProtocols
     ++ "enum "
     ++ prettyMoatTypeHeader newtypeName newtypeTyVars
+    ++ prettyProtocols newtypeProtocols
     ++ " {\n"
     ++ indents
     ++ "typealias "


### PR DESCRIPTION
I had an issue where I was getting

```
 : Protocols...enum X {
```

Here, I move the `enum X` to before `: Protocols`