### PR TITLE
Minor updates to Swift types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle/

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -55,7 +55,7 @@ prettySwiftDataWith indent = \case
     ++ prettyMoatType aliasTyp
 
   MoatNewtype{..} -> ""
-    ++ "enum "
+    ++ "struct "
     ++ prettyMoatTypeHeader newtypeName newtypeTyVars
     ++ prettyProtocols newtypeProtocols
     ++ " {\n"
@@ -214,7 +214,7 @@ prettyStructFields indents = go
     go ((fieldName,ty):fs) = indents ++ "let " ++ fieldName ++ ": " ++ prettyMoatType ty ++ "\n" ++ go fs
 
 prettyNewtypeField :: String -> (String, MoatType) -> String -> String
-prettyNewtypeField indents (alias, _) fieldName = indents ++ "let " ++ alias ++ ": " ++ fieldName ++ "." ++ fieldName ++ "Tag" ++ "\n"
+prettyNewtypeField indents (alias, _) fieldName = indents ++ "let " ++ alias ++ ": " ++ fieldName ++ "Tag" ++ "\n"
 
 prettyPrivateTypes :: String -> [MoatData] -> String
 prettyPrivateTypes indents = go

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -68,6 +68,7 @@ prettySwiftDataWith indent = \case
     ++ ", "
     ++ prettyMoatType (snd newtypeField)
     ++ ">\n"
+    ++ prettyNewtypeField indents newtypeField newtypeName
     ++ "}"
 
   where
@@ -211,6 +212,9 @@ prettyStructFields indents = go
   where
     go [] = ""
     go ((fieldName,ty):fs) = indents ++ "let " ++ fieldName ++ ": " ++ prettyMoatType ty ++ "\n" ++ go fs
+
+prettyNewtypeField :: String -> (String, MoatType) -> String -> String
+prettyNewtypeField indents (alias, _) fieldName = indents ++ "let " ++ alias ++ ": " ++ fieldName ++ "." ++ fieldName ++ "Tag" ++ "\n"
 
 prettyPrivateTypes :: String -> [MoatData] -> String
 prettyPrivateTypes indents = go


### PR DESCRIPTION
In this PR,

- Added `dist-newstyle` to .gitignore
- Modified the swift typegen to turn

```swift
enum LongName: Protocols {
￼    typealias LongNameTag = Tagged<LongName, Type>
￼}
```

into

```swift
struct LongName: Protocols {
￼    typealias LongNameTag = Tagged<LongName, Type>
￼    let value: LongNameTag
￼}
```

This allows the `mobileGenWith` to take, e.g., `fieldLabelModifier = const "somethingElse"` to modify the structure of the JSON