### PR TITLE
Add flake.nix

### DIFF
--- a/.nix/flake-compat.nix
+++ b/.nix/flake-compat.nix
@@ -1,0 +1,4 @@
+import (builtins.fetchGit {
+  url = "https://github.com/edolstra/flake-compat.git";
+  rev = "99f1c2157fba4bfe6211a321fd0ee43199025dbf";
+})

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+let
+  flake-compat = import ./.nix/flake-compat.nix {
+    src = ./.;
+  };
+in
+flake-compat.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1618801528,
+        "narHash": "sha256-1ru9LzP33ElEAZcDzYLgJQG3/uHhAg0LFJEfVZSOPZg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0a5f5bab0e08e968ef25cff393312aa51a3512cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1618801528,
-        "narHash": "sha256-1ru9LzP33ElEAZcDzYLgJQG3/uHhAg0LFJEfVZSOPZg=",
+        "lastModified": 1612545171,
+        "narHash": "sha256-AZkSuO7H055eDD4KWBEDCX/R5fvw0vUMCErvQvYSEhA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a5f5bab0e08e968ef25cff393312aa51a3512cf",
+        "rev": "536fe36e23ab0fc8b7f35c24603422eee9fc17a2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "536fe36e23ab0fc8b7f35c24603422eee9fc17a2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,50 +2,66 @@
   description = "Generate swift and kotlin types from haskell types";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=536fe36e23ab0fc8b7f35c24603422eee9fc17a2";
   };
 
   outputs = { self, nixpkgs }:
     let
       systems = [ "x86_64-darwin" "x86_64-linux" ];
 
+      haskells = [ "ghc884" "ghc8103" ];
+
       eachSystem = nixpkgs.lib.genAttrs systems;
 
       pkgsBySystem = eachSystem (system: nixpkgs.legacyPackages.${system});
 
+      moat =
+        { mkDerivation, base, bytestring, case-insensitive
+        , containers, hpack, hspec, hspec-golden, lib, mtl, primitive
+        , template-haskell, text, th-abstraction, time
+        , unordered-containers, uuid-types, vector
+        }:
+        mkDerivation {
+          pname = "moat";
+          version = "0.1";
+
+          src = ./.;
+
+          libraryHaskellDepends = [
+            base bytestring case-insensitive containers mtl primitive
+            template-haskell text th-abstraction time unordered-containers
+            uuid-types vector
+          ];
+
+          libraryToolDepends = [ hpack ];
+
+          testHaskellDepends = [
+            base bytestring case-insensitive containers hspec hspec-golden mtl
+            primitive template-haskell text th-abstraction time
+            unordered-containers uuid-types vector
+          ];
+
+          homepage = "https://github.com/chessai/moat#readme";
+          description = "Generate swift and kotlin types from haskell types";
+          license = lib.licenses.mit;
+        };
+
     in
     {
       defaultPackage = eachSystem (system:
+        self.packages.${system}.moat-ghc8103
+      );
+
+      packages = eachSystem (system:
         let
           pkgs = pkgsBySystem.${system};
-          moat =
-            { mkDerivation, base, bytestring, case-insensitive
-            , containers, hpack, hspec, hspec-golden, lib, mtl, primitive
-            , template-haskell, text, th-abstraction, time
-            , unordered-containers, uuid-types, vector
-            }:
-            mkDerivation {
-              pname = "moat";
-              version = "0.1";
-              src = ./.;
-              libraryHaskellDepends = [
-                base bytestring case-insensitive containers mtl primitive
-                template-haskell text th-abstraction time unordered-containers
-                uuid-types vector
-              ];
-              libraryToolDepends = [ hpack ];
-              testHaskellDepends = [
-                base bytestring case-insensitive containers hspec hspec-golden mtl
-                primitive template-haskell text th-abstraction time
-                unordered-containers uuid-types vector
-              ];
-              prePatch = "hpack";
-              homepage = "https://github.com/chessai/moat#readme";
-              description = "Generate swift and kotlin types from haskell types";
-              license = lib.licenses.mit;
-            };
+
+          moats = map (haskell: {
+            name = "moat-${haskell}";
+            value = pkgs.haskell.packages.${haskell}.callPackage moat { };
+          }) haskells;
         in
-        pkgs.haskellPackages.callPackage moat { }
+        builtins.listToAttrs moats
       );
 
       devShell = eachSystem (system:
@@ -55,7 +71,7 @@
           pkgs.mkShell {
             name = "moat-shell";
             inputsFrom = [ self.defaultPackage.${system} ];
-            buildInputs = with pkgs.haskellPackages; [
+            buildInputs = with pkgs.haskell.packages.ghc8103; [
               cabal-install
               ghc
               ghcid

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "Generate swift and kotlin types from haskell types";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-darwin" "x86_64-linux" ];
+
+      eachSystem = nixpkgs.lib.genAttrs systems;
+
+      pkgsBySystem = eachSystem (system: nixpkgs.legacyPackages.${system});
+
+    in
+    {
+      defaultPackage = eachSystem (system:
+        let
+          pkgs = pkgsBySystem.${system};
+          moat =
+            { mkDerivation, base, bytestring, case-insensitive
+            , containers, hpack, hspec, hspec-golden, lib, mtl, primitive
+            , template-haskell, text, th-abstraction, time
+            , unordered-containers, uuid-types, vector
+            }:
+            mkDerivation {
+              pname = "moat";
+              version = "0.1";
+              src = ./.;
+              libraryHaskellDepends = [
+                base bytestring case-insensitive containers mtl primitive
+                template-haskell text th-abstraction time unordered-containers
+                uuid-types vector
+              ];
+              libraryToolDepends = [ hpack ];
+              testHaskellDepends = [
+                base bytestring case-insensitive containers hspec hspec-golden mtl
+                primitive template-haskell text th-abstraction time
+                unordered-containers uuid-types vector
+              ];
+              prePatch = "hpack";
+              homepage = "https://github.com/chessai/moat#readme";
+              description = "Generate swift and kotlin types from haskell types";
+              license = lib.licenses.mit;
+            };
+        in
+        pkgs.haskellPackages.callPackage moat { }
+      );
+
+      devShell = eachSystem (system:
+        let
+          pkgs = pkgsBySystem.${system};
+        in
+          pkgs.mkShell {
+            name = "moat-shell";
+            inputsFrom = [ self.defaultPackage.${system} ];
+            buildInputs = with pkgs.haskellPackages; [
+              cabal-install
+              ghc
+              ghcid
+              hpack
+            ];
+          }
+      );
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+let
+  flake-compat = import ./.nix/flake-compat.nix {
+    src = ./.;
+  };
+in
+flake-compat.shellNix


### PR DESCRIPTION
Add `flake.nix` with `defaultPackage` and `devShell` outputs.

This should still work with normal Nix using [flake-compat](https://github.com/edolstra/flake-compat).