### PR TITLE
Fix bug with Result ordering

### DIFF
--- a/.golden/kotlinNewtype3/golden
+++ b/.golden/kotlinNewtype3/golden
@@ -1,0 +1,1 @@
+inline class Newtype3(val newtype3: Either<String, Int>)

--- a/.golden/swiftNewtype3/golden
+++ b/.golden/swiftNewtype3/golden
@@ -1,0 +1,4 @@
+struct Newtype3 {
+    typealias Newtype3Tag = Tagged<Newtype3, Result<Int, String>>
+    let newtype3: Newtype3Tag
+}

--- a/src/Moat/Class.hs
+++ b/src/Moat/Class.hs
@@ -61,13 +61,8 @@ instance forall a b. (ToMoatType a, ToMoatType b) => ToMoatType (a -> b) where
 instance forall a. ToMoatType a => ToMoatType (Maybe a) where
   toMoatType _ = Optional (toMoatType (Proxy @a))
 
--- | /Note/: In Swift, the ordering of the type
---   variables is flipped - Shwifty has made the
---   design choice to flip them for you. If you
---   take issue with this, please open an issue
---   for discussion on GitHub.
 instance forall a b. (ToMoatType a, ToMoatType b) => ToMoatType (Either a b) where
-  toMoatType _ = Result (toMoatType (Proxy @b)) (toMoatType (Proxy @a))
+  toMoatType _ = Result (toMoatType (Proxy @a)) (toMoatType (Proxy @b))
 
 instance ToMoatType Integer where
   toMoatType _ = BigInt

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -160,7 +160,8 @@ prettyMoatType = \case
   Tuple2 e1 e2 -> "(" ++ prettyMoatType e1 ++ ", " ++ prettyMoatType e2 ++ ")"
   Tuple3 e1 e2 e3 -> "(" ++ prettyMoatType e1 ++ ", " ++ prettyMoatType e2 ++ ", " ++ prettyMoatType e3 ++ ")"
   Optional e -> prettyMoatType e ++ "?"
-  Result e1 e2 -> "Result<" ++ prettyMoatType e1 ++ ", " ++ prettyMoatType e2 ++ ">"
+  -- Swift flips the parameters for Result, see https://developer.apple.com/documentation/swift/result
+  Result e1 e2 -> "Result<" ++ prettyMoatType e2 ++ ", " ++ prettyMoatType e1 ++ ">"
   Set e -> "Set<" ++ prettyMoatType e ++ ">"
   Dictionary e1 e2 -> "Dictionary<" ++ prettyMoatType e1 ++ ", " ++ prettyMoatType e2 ++ ">"
   Array e -> "[" ++ prettyMoatType e ++ "]"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -151,6 +151,10 @@ mobileGenWith
   )
   ''Newtype2
 
+newtype Newtype3 = Newtype3 {newtype3 :: Either String Int}
+
+mobileGen ''Newtype3
+
 showKotlin :: forall a. ToMoatData a => String
 showKotlin = prettyKotlinData $ toMoatData (Proxy @a)
 
@@ -168,6 +172,8 @@ main = hspec $ do
       defaultGolden "kotlinNewtype1" (showKotlin @Newtype1)
     it "kotlinNewtype2" $
       defaultGolden "kotlinNewtype2" (showKotlin @Newtype2)
+    it "kotlinNewtype3" $
+      defaultGolden "kotlinNewtype3" (showKotlin @Newtype3)
     it "kotlinData0" $
       defaultGolden "kotlinData0" (showKotlin @Data0)
     it "kotlinEnum1" $

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -199,6 +199,8 @@ main = hspec $ do
       defaultGolden "swiftNewtype1" (showSwift @Newtype1)
     it "swiftNewtype2" $
       defaultGolden "swiftNewtype2" (showSwift @Newtype2)
+    it "swiftNewtype3" $
+      defaultGolden "swiftNewtype3" (showSwift @Newtype3)
     it "swiftData0" $
       defaultGolden "swiftData0" (showSwift @Data0)
     it "swiftEnum1" $


### PR DESCRIPTION
The order of the parameters for result were flipped to facilitate Swift, however most languages have the `Left` type first and therefore it is incredibly confusing when adding a new backend. e.g. this bug was found in the current Kotlin backend.