### PR TITLE
Add basic nix build github action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,14 @@
+name: "Run nix build"
+on:
+  push:
+    branches:
+      - master
+jobs:
+  generate-readme:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v14
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build


### PR DESCRIPTION
Closes #25 

We should try to run the tests by building via `nix build`