### PR TITLE
Implement optionalExpand feature

### DIFF
--- a/.golden/kotlinBasicRecordWithExpandOptionalSpec/golden
+++ b/.golden/kotlinBasicRecordWithExpandOptionalSpec/golden
@@ -1,0 +1,4 @@
+data class Data(
+    val field0: Int,
+    val field1: Int? = null,
+)

--- a/.golden/swiftBasicRecordWithExpandOptionalSpec/golden
+++ b/.golden/swiftBasicRecordWithExpandOptionalSpec/golden
@@ -1,0 +1,4 @@
+struct Data {
+    let field0: Int
+    let field1: Optional<Int>
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -67,6 +67,7 @@ test-suite spec
       BasicNewtypeWithConcreteFieldSpec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
+      BasicRecordWithExpandOptionalSpec
       Common
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -140,7 +140,9 @@ data MoatData
         -- | The tags of the struct. See 'Tag'.
         --
         --   Only used by the Swift backend.
-        structTags :: [MoatType]
+        structTags :: [MoatType],
+        -- | See 'optionalExpand' for understanding this parameter
+        structOptionalExpand :: Bool
       }
   | -- | An enum, sum, or coproduct type
     MoatEnum
@@ -177,7 +179,9 @@ data MoatData
         -- | The tags of the struct. See 'Tag'.
         --
         --   Only used by the Swift backend.
-        enumTags :: [MoatType]
+        enumTags :: [MoatType],
+        -- | See 'optionalExpand' for understanding this parameter
+        enumOptionalExpand :: Bool
       }
   | -- | A newtype.
     --   Kotlin backend: becomes a value class.
@@ -188,7 +192,9 @@ data MoatData
         newtypeField :: (String, MoatType),
         newtypeInterfaces :: [Interface],
         newtypeProtocols :: [Protocol], -- TODO: remove this?
-        newtypeAnnotations :: [Annotation]
+        newtypeAnnotations :: [Annotation],
+        -- | See 'optionalExpand' for understanding this parameter
+        newtypeOptionalExpand :: Bool
       }
   | -- | A /top-level/ type alias
     MoatAlias
@@ -197,7 +203,9 @@ data MoatData
         -- | the type variables of the type alias
         aliasTyVars :: [String],
         -- | the type this represents (RHS)
-        aliasTyp :: MoatType
+        aliasTyp :: MoatType,
+        -- | See 'optionalExpand' for understanding this parameter
+        aliasOptionalExpand :: Bool
       }
   deriving stock (Eq, Read, Show, Generic)
 

--- a/test/BasicRecordWithExpandOptionalSpec.hs
+++ b/test/BasicRecordWithExpandOptionalSpec.hs
@@ -1,0 +1,25 @@
+module BasicRecordWithExpandOptionalSpec where
+
+import Common
+import Moat
+import Moat.Types (Options (..))
+import Test.Hspec
+import Test.Hspec.Golden
+
+data Data = Data
+  { field0 :: Int,
+    field1 :: Maybe Int
+  }
+
+mobileGenWith
+  defaultOptions {optionalExpand = True}
+  ''Data
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "BasicRecordWithExpandOptionalSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @Data)
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @Data)


### PR DESCRIPTION
See #26 

This is particularly nasty. We don't really have a choice other than passing these parameters in with each of `MoatData`s records.

We really need a `Reader` in `MoatM` to handle passing around the Options. Additionally, a `Reader` in the pretty swift module would help as well.

- [x] Merge #28 and rebase this PR