### PR TITLE
Use 'value class' syntax for Kotlin newtypes

### DIFF
--- a/.golden/kotlinAdvancedNewtypeSpec/golden
+++ b/.golden/kotlinAdvancedNewtypeSpec/golden
@@ -1,2 +1,3 @@
 @Parcelize
-inline class Newtype(val value: String) : Parcelable
+@JvmInline
+value class Newtype(val value: String) : Parcelable

--- a/.golden/kotlinAdvancedNewtypeWithEnumFieldSpec/golden
+++ b/.golden/kotlinAdvancedNewtypeWithEnumFieldSpec/golden
@@ -1,1 +1,1 @@
-inline class Newtype(val newtypeField: Enum)
+value class Newtype(val newtypeField: Enum)

--- a/.golden/kotlinBasicNewtypeSpec/golden
+++ b/.golden/kotlinBasicNewtypeSpec/golden
@@ -1,1 +1,1 @@
-inline class Newtype(val value: String)
+value class Newtype(val value: String)

--- a/.golden/kotlinBasicNewtypeWithConcreteFieldSpec/golden
+++ b/.golden/kotlinBasicNewtypeWithConcreteFieldSpec/golden
@@ -1,1 +1,1 @@
-inline class Newtype(val newtypeField: String)
+value class Newtype(val newtypeField: String)

--- a/.golden/kotlinBasicNewtypeWithEitherFieldSpec/golden
+++ b/.golden/kotlinBasicNewtypeWithEitherFieldSpec/golden
@@ -1,1 +1,1 @@
-inline class Newtype(val newtypeField: Either<String, Int>)
+value class Newtype(val newtypeField: Either<String, Int>)

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -35,7 +35,7 @@ prettyKotlinData = \case
   MoatNewtype {..} ->
     ""
       ++ prettyAnnotations newtypeAnnotations
-      ++ "inline class "
+      ++ "value class "
       ++ prettyMoatTypeHeader newtypeName newtypeTyVars
       ++ "(val "
       ++ fst newtypeField
@@ -125,6 +125,7 @@ prettyAnnotations = concatMap (\ann -> "@" ++ prettyAnnotation ann ++ "\n")
   where
     prettyAnnotation :: Annotation -> String
     prettyAnnotation = \case
+      JvmInline -> "JvmInline"
       Parcelize -> "Parcelize"
       Serializable -> "Serializable"
       RawAnnotation s -> s

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -229,7 +229,9 @@ data Interface
   deriving stock (Lift)
 
 data Annotation
-  = -- | The 'Parcelize' annotation, see https://developer.android.com/kotlin/parcelize
+  = -- | The 'JvmInline' annotation, see https://kotlinlang.org/docs/inline-classes.html
+    JvmInline
+  | -- | The 'Parcelize' annotation, see https://developer.android.com/kotlin/parcelize
     -- automatically generates a Parcelable implementation for the type
     Parcelize
   | -- | The 'Serializable' annotation, see https://developer.android.com/reference/kotlin/java/io/Serializable

--- a/test/AdvancedNewtypeSpec.hs
+++ b/test/AdvancedNewtypeSpec.hs
@@ -11,7 +11,7 @@ newtype Newtype = Newtype Text
 
 mobileGenWith
   ( defaultOptions
-      { dataAnnotations = [Parcelize],
+      { dataAnnotations = [Parcelize, JvmInline],
         dataInterfaces = [Parcelable],
         dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
       }


### PR DESCRIPTION
This is a simpler alternative to #8, since `inline class` syntax is deprecated and it probably doesn't make sense to support it going forward.

- ~~Add `newtypeAnns` option to set default newtype annotations for Kotlin. I didn't want to collide with `newtypeAnnotations` on `MoatNewtype`, but I'm not well-versed in how to avoid naming collisions in Haskell.~~
- Add the `JvmInline` annotation type as it's very likely to be used by consumers targeting JVM/Android Kotlin backends.
- ~~Construct newtype expressions by combining `dataAnnotations` with `newtypeAnns` from `Options`.~~
- Use `value class` unconditionally for Kotlin newtypes.