### PR TITLE
Configurable sum of product styling

### DIFF
--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
@@ -1,0 +1,14 @@
+@JsonClassDiscriminator("tag")
+@Parcelize
+@Serializable
+sealed class Enum : Parcelable {
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons0")
+    data class DataCons0(val contents: Record0) : Enum()
+
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons1")
+    object DataCons1 : Enum()
+}

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,0 +1,14 @@
+@Parcelize
+@Serializable
+@JsonClassDiscriminator("tag")
+sealed class Enum : Parcelable {
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons0")
+    data class DataCons0(val contents: Record0) : Enum()
+
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons1")
+    data class DataCons1(val contents: Record1) : Enum()
+}

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,6 +1,6 @@
+@JsonClassDiscriminator("tag")
 @Parcelize
 @Serializable
-@JsonClassDiscriminator("tag")
 sealed class Enum : Parcelable {
     @Parcelize
     @Serializable

--- a/.golden/kotlinRecord0SumOfProductWithTaggedObjectAndSingleNullarySpec/golden
+++ b/.golden/kotlinRecord0SumOfProductWithTaggedObjectAndSingleNullarySpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record0(
+    val record0Field0: Int,
+    val record0Field1: Int,
+) : Parcelable

--- a/.golden/kotlinRecord0SumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinRecord0SumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record0(
+    val record0Field0: Int,
+    val record0Field1: Int,
+) : Parcelable

--- a/.golden/kotlinRecord1SumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinRecord1SumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record1(
+    val record1Field0: Int,
+    val record1Field1: Int,
+) : Parcelable

--- a/moat.cabal
+++ b/moat.cabal
@@ -70,6 +70,7 @@ test-suite spec
       Common
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
+      SumOfProductWithTaggedObjectAndSingleNullarySpec
       SumOfProductWithTaggedObjectStyleSpec
       Moat
       Moat.Class

--- a/moat.cabal
+++ b/moat.cabal
@@ -70,6 +70,7 @@ test-suite spec
       Common
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
+      SumOfProductWithTaggedObjectStyleSpec
       Moat
       Moat.Class
       Moat.Pretty.Kotlin

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -44,6 +44,8 @@ module Moat
     -- ** Option type and defaults
     Options,
     defaultOptions,
+    defaultTaggedObjectEncodingStyle,
+    defaultTaggedFlatObjectEncodingStyle,
 
     -- ** Helper type for omissions
     KeepOrDiscard (..),
@@ -64,6 +66,7 @@ module Moat
     omitFields,
     omitCases,
     makeBase,
+    kotlinRenderingStyle,
 
     -- * Pretty-printing
 

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -1467,7 +1467,6 @@ enumExp ::
   [Exp] ->
   -- | Make base?
   (Bool, Maybe MoatType, [Protocol]) ->
-  -- | Documentation
   SumOfProductEncodingOptions ->
   Q Exp
 enumExp parentName tyVars ifaces protos anns cases raw tags bs sop =

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -213,18 +213,32 @@ prettyTaggedObject ::
 prettyTaggedObject parentName anns cases indents SumOfProductEncodingOptions {..} =
   intercalate
     "\n\n"
-    ( cases <&> \(caseNm, [(_, Concrete {concreteName = concreteName})]) ->
-        prettyAnnotations (Just caseNm) indents anns
-          ++ indents
-          ++ "data class "
-          ++ toUpperFirst caseNm
-          ++ "(val "
-          ++ contentsFieldName
-          ++ ": "
-          ++ concreteName
-          ++ ") : "
-          ++ parentName
-          ++ "()"
+    ( cases <&> \case
+        (caseNm, [(_, Concrete {concreteName = concreteName})]) ->
+          prettyAnnotations (Just caseNm) indents anns
+            ++ indents
+            ++ "data class "
+            ++ toUpperFirst caseNm
+            ++ "(val "
+            ++ contentsFieldName
+            ++ ": "
+            ++ concreteName
+            ++ ") : "
+            ++ parentName
+            ++ "()"
+        (caseNm, []) ->
+          prettyAnnotations (Just caseNm) indents anns
+            ++ indents
+            ++ "object "
+            ++ toUpperFirst caseNm
+            ++ " : "
+            ++ parentName
+            ++ "()"
+        (caseNm, _) ->
+          error $
+            "prettyTaggedObject: The data constructor "
+              <> caseNm
+              <> " can have zero or one concrete type constructor!"
     )
 
 prettyEnum ::

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -134,7 +134,7 @@ prettyAnnotations mCaseNm indents =
       JvmInline -> "JvmInline"
       Parcelize -> "Parcelize"
       Serializable -> "Serializable"
-      SerialName -> maybe Nothing (\caseNm -> Just $ "SerialName(\"" <> caseNm <> "\")") mCaseNm
+      SerialName -> mCaseNm <&> \caseNm -> "SerialName(\"" <> caseNm <> "\")"
       RawAnnotation s -> s
 
 prettyInterfaces :: [Interface] -> String

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -123,6 +123,9 @@ prettyMoatTypeHeader :: String -> [String] -> String
 prettyMoatTypeHeader name [] = name
 prettyMoatTypeHeader name tyVars = name ++ "<" ++ intercalate ", " tyVars ++ ">"
 
+-- | This function will take a name and the indentation level and render
+-- annotations in the style '@{string}\n...'. The name parameter is only used
+-- when a 'SerialName' annotation is given for a sum of product
 prettyAnnotations :: Maybe String -> String -> [Annotation] -> String
 prettyAnnotations mCaseNm indents =
   concatMap (\ann -> indents <> "@" <> ann <> "\n")

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -31,6 +31,7 @@ prettyKotlinData = \case
       enumName
       enumTyVars
       enumCases
+      enumEncodingStyle
       indents
   MoatNewtype {..} ->
     ""
@@ -204,10 +205,12 @@ prettyEnum ::
   [String] ->
   -- | cases
   [(String, [(Maybe String, MoatType)])] ->
+  -- | encoding style
+  EncodingStyle ->
   -- | indents
   String ->
   String
-prettyEnum anns ifaces name tyVars cases indents
+prettyEnum anns ifaces name tyVars cases es indents
   | isCEnum cases =
     prettyAnnotations (dontAddSerializeToEnums anns)
       ++ "enum class "

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -195,8 +195,14 @@ prettyApp t1 t2 =
       (args, ret) -> (e1 : args, ret)
     go e1 e2 = ([e1], e2)
 
-prettySerialName :: String -> [Annotation] -> [(String, [(Maybe String, MoatType)])] -> String -> TaggedObject -> String
-prettySerialName parentName anns cases indents TaggedObject {..} =
+prettyTaggedObject ::
+  String ->
+  [Annotation] ->
+  [(String, [(Maybe String, MoatType)])] ->
+  String ->
+  TaggedObject ->
+  String
+prettyTaggedObject parentName anns cases indents TaggedObject {..} =
   intercalate
     "\n\n"
     ( cases <&> \(caseNm, [(_, Concrete {concreteName = concreteName})]) ->
@@ -254,7 +260,7 @@ prettyEnum anns ifaces name tyVars cases es indents
           ++ prettyMoatTypeHeader name tyVars
           ++ prettyInterfaces ifaces
           ++ " {\n"
-          ++ prettySerialName name anns cases indents to
+          ++ prettyTaggedObject name anns cases indents to
           ++ "\n}"
   | otherwise =
     prettyAnnotations noIndent (dontAddSerializeToEnums anns)

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -37,7 +37,7 @@ prettyKotlinData = \case
       indents
   MoatNewtype {..} ->
     ""
-      ++ prettyAnnotations newtypeAnnotations
+      ++ prettyAnnotations Nothing noIndent newtypeAnnotations
       ++ "value class "
       ++ prettyMoatTypeHeader newtypeName newtypeTyVars
       ++ "(val "
@@ -134,11 +134,11 @@ prettyAnnotations mCaseNm indents =
   where
     prettyAnnotation :: Annotation -> Maybe String
     prettyAnnotation = \case
-      JvmInline -> "JvmInline"
-      Parcelize -> "Parcelize"
-      Serializable -> "Serializable"
+      JvmInline -> Just "JvmInline"
+      Parcelize -> Just "Parcelize"
+      Serializable -> Just "Serializable"
       SerialName -> mCaseNm <&> \caseNm -> "SerialName(\"" <> caseNm <> "\")"
-      RawAnnotation s -> s
+      RawAnnotation s -> Just s
 
 prettyInterfaces :: [Interface] -> String
 prettyInterfaces [] = ""

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -398,23 +398,46 @@ data Options = Options
     --   will keep it as sugar. A value of 'True'
     --   will expand it to be desugared.
     optionalExpand :: Bool,
-    -- | Documentation
+    -- | Only applies for a sum in a sum of products. The options
+    -- determine the rendering style for the sum of products.
+    -- The user is responsible for choosing the right options
+    -- for the products in a SOP. See 'SumOfProductEncodingOptions'
     sumOfProductEncodingOptions :: SumOfProductEncodingOptions
   }
 
--- Documentation
 data SumOfProductEncodingOptions = SumOfProductEncodingOptions
-  { encodingStyle :: EncodingStyle,
+  { -- | The encoding style for the sum of product, the library matches the options
+    -- available in aeson, see
+    -- https://hackage.haskell.org/package/aeson/docs/Data-Aeson-TH.html#t:SumEncoding
+    -- and 'EncodingStyle'
+    encodingStyle :: EncodingStyle,
+    -- | The annotations to add solely to sum in the sum of product, e.g.
+    -- in kotlinx.serialization we want to add '@JsonClassDiscriminator("tag")'
+    -- annotation to the sum type but not the products!
     sumAnnotations :: [Annotation],
+    -- | The field name to use for the products, aeson uses "contents" for the TaggedObject
+    -- style. This is unused in the 'TaggedFlatObjectStyle'
     contentsFieldName :: String
   }
   deriving stock (Eq, Read, Show, Lift)
 
--- Documentation
+-- | The resulting enum style for our datatype. This names match
+-- the style in Aeson. A 'TaggedObjectStyle' will have a JSON
+-- payload like,
+--
+-- @
+-- {
+--   "tag": ...,
+--   "contents": ...
+-- }
+-- @
+--
+-- In 'TaggedFlatObjectStyle', the contents are unpacked at the same
+-- level as "tag"
 data EncodingStyle = TaggedObjectStyle | TaggedFlatObjectStyle
   deriving stock (Eq, Read, Show, Lift)
 
--- Documentation
+-- | The default 'SumOfProductEncodingOptions'
 defaultSumOfProductEncodingOptions :: SumOfProductEncodingOptions
 defaultSumOfProductEncodingOptions =
   SumOfProductEncodingOptions

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -243,7 +243,9 @@ data Annotation
     Serializable
   | -- | /escape hatch/ to add an arbitrary annotation
     RawAnnotation String
-  | -- | The 'SerialName' annotation only applies for products in sum of products
+  | -- | The 'SerialName' annotation is an annotation for products in a sum of
+    -- products and only applies when used on the sum, see
+    -- https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-core/kotlinx-serialization-core/kotlinx.serialization/-serial-name/index.html
     SerialName
   deriving stock (Eq, Read, Show)
   deriving stock (Lift)

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -243,6 +243,8 @@ data Annotation
     Serializable
   | -- | /escape hatch/ to add an arbitrary annotation
     RawAnnotation String
+  | -- | The 'SerialName' annotation only applies for products in sum of products
+    SerialName
   deriving stock (Eq, Read, Show)
   deriving stock (Lift)
 

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -182,7 +182,9 @@ data MoatData
         -- | The tags of the struct. See 'Tag'.
         --
         --   Only used by the Swift backend.
-        enumTags :: [MoatType]
+        enumTags :: [MoatType],
+        -- |
+        enumEncodingStyle :: EncodingStyle
       }
   | -- | A newtype.
     --   Kotlin backend: becomes a value class.
@@ -396,7 +398,7 @@ data Options = Options
     optionalExpand :: Bool,
     -- | The encoding style for sum of products in Kotlin,
     -- see 'TaggedObject' and 'TaggedFlatObject' for details
-    kotlinRenderingStyle :: EncodingStyle
+    encodingStyle :: EncodingStyle
   }
 
 -- The 'TaggedObject' style will encode a sum of products where the parent sum has
@@ -407,6 +409,7 @@ data Options = Options
 data EncodingStyle
   = TaggedObjectStyle TaggedObject
   | TaggedFlatObjectStyle TaggedFlatObject
+  deriving stock (Eq, Read, Show, Lift)
 
 -- | The contents of a tagged object are inside of the 'contentsFieldName', e.g.
 --
@@ -420,6 +423,7 @@ data TaggedObject = TaggedObject
   { tagFieldName :: String,
     contentsFieldName :: String
   }
+  deriving stock (Eq, Read, Show, Lift)
 
 defaultTaggedObjectEncodingStyle :: EncodingStyle
 defaultTaggedObjectEncodingStyle =
@@ -440,6 +444,7 @@ defaultTaggedObjectEncodingStyle =
 newtype TaggedFlatObject = TaggedFlatObject
   { taggedFlatObjectTagFieldName :: String
   }
+  deriving stock (Eq, Read, Show, Lift)
 
 defaultTaggedFlatObjectEncodingStyle :: EncodingStyle
 defaultTaggedFlatObjectEncodingStyle =
@@ -494,7 +499,7 @@ defaultOptions =
       makeBase = (False, Nothing, []),
       optionalExpand = False,
       -- TODO: we should split backend configuration into their own ADTs
-      kotlinRenderingStyle = defaultTaggedFlatObjectEncodingStyle
+      encodingStyle = defaultTaggedFlatObjectEncodingStyle
     }
 
 data KeepOrDiscard = Keep | Discard

--- a/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
@@ -1,0 +1,47 @@
+module SumOfProductWithTaggedObjectAndSingleNullarySpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Record0 = Record0
+  { record0Field0 :: Int,
+    record0Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable]
+      }
+  )
+  ''Record0
+
+data Enum
+  = DataCons0 Record0
+  | DataCons1
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable, SerialName],
+        dataInterfaces = [Parcelable],
+        sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle,
+              sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"],
+              contentsFieldName = "contents"
+            }
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithTaggedObjectAndSingleNullarySpec"
+    it "kotlin" $
+      defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Record0)
+    it "kotlin" $
+      defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -14,8 +14,7 @@ data Record0 = Record0
 mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
-        dataInterfaces = [Parcelable],
-        encodingStyle = defaultTaggedObjectEncodingStyle
+        dataInterfaces = [Parcelable]
       }
   )
   ''Record0
@@ -28,8 +27,7 @@ data Record1 = Record1
 mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
-        dataInterfaces = [Parcelable],
-        encodingStyle = defaultTaggedObjectEncodingStyle
+        dataInterfaces = [Parcelable]
       }
   )
   ''Record1
@@ -42,7 +40,12 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
         dataInterfaces = [Parcelable],
-        encodingStyle = defaultTaggedObjectEncodingStyle
+        sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle,
+              sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"],
+              contentsFieldName = "contents"
+            }
       }
   )
   ''Enum

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -38,7 +38,7 @@ data Enum
 
 mobileGenWith
   ( defaultOptions
-      { dataAnnotations = [Parcelize, Serializable],
+      { dataAnnotations = [Parcelize, Serializable, SerialName],
         dataInterfaces = [Parcelable],
         sumOfProductEncodingOptions =
           SumOfProductEncodingOptions

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -15,7 +15,7 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
         dataInterfaces = [Parcelable],
-        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+        encodingStyle = defaultTaggedObjectEncodingStyle
       }
   )
   ''Record0
@@ -29,7 +29,7 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
         dataInterfaces = [Parcelable],
-        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+        encodingStyle = defaultTaggedObjectEncodingStyle
       }
   )
   ''Record1
@@ -42,7 +42,7 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable],
         dataInterfaces = [Parcelable],
-        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+        encodingStyle = defaultTaggedObjectEncodingStyle
       }
   )
   ''Enum

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -1,0 +1,59 @@
+module SumOfProductWithTaggedObjectStyleSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Record0 = Record0
+  { record0Field0 :: Int,
+    record0Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+      }
+  )
+  ''Record0
+
+data Record1 = Record1
+  { record1Field0 :: Int,
+    record1Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+      }
+  )
+  ''Record1
+
+data Enum
+  = DataCons0 Record0
+  | DataCons1 Record1
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        kotlinRenderingStyle = defaultTaggedObjectEncodingStyle
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithTaggedObjectStyleSpec"
+    it "kotlin" $
+      defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Record0)
+    it "kotlin" $
+      defaultGolden ("kotlinRecord1" <> moduleName) (showKotlin @Record1)
+    it "kotlin" $
+      defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)


### PR DESCRIPTION
This is a *much* less intrusive version of #33. Introduce a configuration option to handle the various encoding styles of Aeson (see https://hackage.haskell.org/package/aeson-2.0.1.0/docs/Data-Aeson-TH.html#t:SumEncoding). We are using a non-existent style that was suggested in [this PR](https://github.com/haskell/aeson/pull/828).

Spawns a few issues:
- aeson's encoding styles should be supported for all backends #36 
- language specific options should be separated into their own ADTs #13 