### PR TITLE
Implement non-Nix CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.4"]
-        ghc: ["8.6.5", "8.8.4", "8.10.4", "9.0.1"]
+        cabal: ["3.6"]
+        ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.2"]
     env:
       CONFIG: "--enable-tests"
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,41 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal: ["3.4"]
+        ghc: ["8.6.5", "8.8.4", "8.10.4", "9.0.1"]
+    env:
+      CONFIG: "--enable-tests"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: cabal v2-update
+      - run: cabal v2-freeze $CONFIG
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal v2-build --disable-optimization -j $CONFIG
+      - run: cabal v2-test --disable-optimization -j $CONFIG
+      - run: cabal v2-haddock -j $CONFIG
+      - run: cabal v2-sdist
+

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       moat =
         { mkDerivation, base, bytestring, case-insensitive
         , containers, hpack, hspec, hspec-golden, lib, mtl, primitive
-        , template-haskell, text, th-abstraction, time
+        , template-haskell, text, th-abstraction, th-compat, time
         , unordered-containers, uuid-types, vector
         }:
         mkDerivation {

--- a/moat.cabal
+++ b/moat.cabal
@@ -41,7 +41,7 @@ library
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base >=4.11 && <4.16
+      base >=4.11 && <4.17
     , bytestring ==0.10.*
     , case-insensitive ==1.2.*
     , containers >=0.5.9 && <0.7

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -42,12 +42,12 @@ library
       hspec-discover:hspec-discover
   build-depends:
       base >=4.11 && <4.17
-    , bytestring ==0.10.*
+    , bytestring >=0.10 && <0.12
     , case-insensitive ==1.2.*
     , containers >=0.5.9 && <0.7
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.11 && <2.18
+    , template-haskell >=2.11 && <2.19
     , text ==1.2.*
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2
@@ -98,8 +98,8 @@ test-suite spec
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base >=4.11 && <4.16
-    , bytestring ==0.10.*
+      base >=4.11 && <4.17
+    , bytestring >=0.10 && <0.12
     , case-insensitive ==1.2.*
     , containers >=0.5.9 && <0.7
     , hspec
@@ -107,7 +107,7 @@ test-suite spec
     , hspec-golden
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.11 && <2.18
+    , template-haskell >=2.11 && <2.19
     , text ==1.2.*
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2

--- a/package.yaml
+++ b/package.yaml
@@ -16,13 +16,13 @@ default-extensions:
   - RecordWildCards
 
 dependencies:
-  - base >= 4.11 && < 4.16
-  - bytestring >= 0.10 && < 0.11
+  - base >= 4.11 && < 4.17
+  - bytestring >= 0.10 && < 0.12
   - case-insensitive >= 1.2 && < 1.3
   - containers >= 0.5.9 && < 0.7
   - mtl >= 2.2 && < 2.3
   - primitive >= 0.6.4 && < 0.8
-  - template-haskell >= 2.11 && < 2.18
+  - template-haskell >= 2.11 && < 2.19
   - text >= 1.2 && < 1.3
   - th-abstraction >= 0.3 && < 0.5
   - th-compat >= 0.1.0 && < 0.2


### PR DESCRIPTION
This PR adds a typical `cabal` based build CI, allowing for multiple GHCs and package dependencies. This will be more robust to providing a stable library interface and minimizing breaks.