### PR TITLE
Kotlin: Fix sum-of-product encoding

### DIFF
--- a/.golden/kotlinEnumSumOfProductSpec/golden
+++ b/.golden/kotlinEnumSumOfProductSpec/golden
@@ -1,11 +1,2 @@
-@Parcelize
-enum class Enum : Parcelable {
-    data class DataCons0(
-        val enumField0: Int,
-        val enumField1: Int
-    )
-    data class DataCons1(
-        val enumField2: String,
-        val enumField3: String
-    )
-}
+@Serializable
+sealed class Enum : Parcelable

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
@@ -1,0 +1,13 @@
+@JsonClassDiscriminator("tag")
+@Serializable
+sealed class Enum : Parcelable {
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons0")
+    data class DataCons0(val contents: List<Record0>) : Enum()
+
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons1")
+    data class DataCons1(val contents: List<Record1>) : Enum()
+}

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
@@ -1,5 +1,4 @@
 @JsonClassDiscriminator("tag")
-@Parcelize
 @Serializable
 sealed class Enum : Parcelable {
     @Parcelize

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,5 +1,4 @@
 @JsonClassDiscriminator("tag")
-@Parcelize
 @Serializable
 sealed class Enum : Parcelable {
     @Parcelize

--- a/.golden/kotlinRecord0SumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
+++ b/.golden/kotlinRecord0SumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record0(
+    val record0Field0: Int,
+    val record0Field1: Int,
+) : Parcelable

--- a/.golden/kotlinRecord1SumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
+++ b/.golden/kotlinRecord1SumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record1(
+    val record1Field0: Int,
+    val record1Field1: Int,
+) : Parcelable

--- a/.nix/flake-compat.nix
+++ b/.nix/flake-compat.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchGit {
   url = "https://github.com/edolstra/flake-compat.git";
-  rev = "99f1c2157fba4bfe6211a321fd0ee43199025dbf";
+  rev = "b4a34015c698c7793d592d66adbab377907a2be8";
 })

--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,14 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1612545171,
-        "narHash": "sha256-AZkSuO7H055eDD4KWBEDCX/R5fvw0vUMCErvQvYSEhA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "536fe36e23ab0fc8b7f35c24603422eee9fc17a2",
-        "type": "github"
+        "lastModified": 0,
+        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
+        "path": "/nix/store/3ds4cwrnkgfvpjgf80vr2dbw9yfrrnsv-source",
+        "type": "path"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "536fe36e23ab0fc8b7f35c24603422eee9fc17a2",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,85 +1,55 @@
 {
   description = "Generate swift and kotlin types from haskell types";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=536fe36e23ab0fc8b7f35c24603422eee9fc17a2";
-  };
-
   outputs = { self, nixpkgs }:
     let
-      systems = [ "x86_64-darwin" "x86_64-linux" ];
+      systems = [ "aarch64-darwin" "x86_64-darwin" "x86_64-linux" ];
 
-      haskells = [ "ghc884" "ghc8103" ];
+      haskells = [ "ghc8107" "ghc902" "ghc922" ];
 
       eachSystem = nixpkgs.lib.genAttrs systems;
 
+      eachHaskell = nixpkgs.lib.genAttrs haskells;
+
+      latestHaskell = nixpkgs.lib.last haskells;
+
       pkgsBySystem = eachSystem (system: nixpkgs.legacyPackages.${system});
-
-      moat =
-        { mkDerivation, base, bytestring, case-insensitive
-        , containers, hpack, hspec, hspec-golden, lib, mtl, primitive
-        , template-haskell, text, th-abstraction, th-compat, time
-        , unordered-containers, uuid-types, vector
-        }:
-        mkDerivation {
-          pname = "moat";
-          version = "0.1";
-
-          src = ./.;
-
-          libraryHaskellDepends = [
-            base bytestring case-insensitive containers mtl primitive
-            template-haskell text th-abstraction time unordered-containers
-            uuid-types vector
-          ];
-
-          libraryToolDepends = [ hpack ];
-
-          testHaskellDepends = [
-            base bytestring case-insensitive containers hspec hspec-golden mtl
-            primitive template-haskell text th-abstraction time
-            unordered-containers uuid-types vector
-          ];
-
-          homepage = "https://github.com/chessai/moat#readme";
-          description = "Generate swift and kotlin types from haskell types";
-          license = lib.licenses.mit;
-        };
 
     in
     {
-      defaultPackage = eachSystem (system:
-        self.packages.${system}.moat-ghc8103
-      );
-
       packages = eachSystem (system:
         let
           pkgs = pkgsBySystem.${system};
 
-          moats = map (haskell: {
+          moats = builtins.listToAttrs (map (haskell: {
             name = "moat-${haskell}";
-            value = pkgs.haskell.packages.${haskell}.callPackage moat { };
-          }) haskells;
+            value = pkgs.haskell.packages.${haskell}.callPackage ./moat.nix { };
+          }) haskells);
         in
-        builtins.listToAttrs moats
+        moats // { default = moats."moat-${latestHaskell}"; }
       );
 
-      devShell = eachSystem (system:
+      devShells = eachSystem (system:
         let
           pkgs = pkgsBySystem.${system};
+          shells = eachHaskell (haskell:
+            pkgs.mkShell {
+              name = "moat-${haskell}-shell";
+              inputsFrom = [ self.packages.${system}."moat-${haskell}" ];
+              nativeBuildInputs = with pkgs.haskell.packages.${haskell}; [
+                cabal2nix
+                cabal-install
+                ghc
+                ghcid
+                haskell-language-server
+                hlint
+                hpack
+                ormolu
+              ];
+            }
+          );
         in
-          pkgs.mkShell {
-            name = "moat-shell";
-            inputsFrom = [ self.defaultPackage.${system} ];
-            buildInputs = with pkgs.haskell.packages.ghc8103; [
-              cabal-install
-              ghc
-              ghcid
-              hpack
-              ormolu
-              hlint
-            ];
-          }
+        shells // { default = shells.${latestHaskell}; }
       );
     };
 }

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -75,6 +75,7 @@ test-suite spec
       Common
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
+      SumOfProductWithTaggedObjectAndNonConcreteCasesSpec
       SumOfProductWithTaggedObjectAndSingleNullarySpec
       SumOfProductWithTaggedObjectStyleSpec
       Moat

--- a/moat.nix
+++ b/moat.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, hpack, hspec, hspec-discover, hspec-golden, lib, mtl, primitive
+, template-haskell, text, th-abstraction, th-compat, time
+, unordered-containers, uuid-types, vector
+}:
+mkDerivation {
+  pname = "moat";
+  version = "0.1";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers mtl primitive
+    template-haskell text th-abstraction th-compat time
+    unordered-containers uuid-types vector
+  ];
+  libraryToolDepends = [ hpack hspec-discover ];
+  testHaskellDepends = [
+    base bytestring case-insensitive containers hspec hspec-discover
+    hspec-golden mtl primitive template-haskell text th-abstraction
+    th-compat time unordered-containers uuid-types vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  prePatch = "hpack";
+  homepage = "https://github.com/chessai/moat#readme";
+  description = "Generate swift and kotlin types from haskell types";
+  license = lib.licenses.mit;
+}

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -214,7 +214,7 @@ prettyTaggedObject parentName anns cases indents SumOfProductEncodingOptions {..
   intercalate
     "\n\n"
     ( cases <&> \case
-        (caseNm, [(_, Concrete {concreteName = concreteName})]) ->
+        (caseNm, [(_, caseTy)]) ->
           prettyAnnotations (Just caseNm) indents anns
             ++ indents
             ++ "data class "
@@ -222,7 +222,7 @@ prettyTaggedObject parentName anns cases indents SumOfProductEncodingOptions {..
             ++ "(val "
             ++ contentsFieldName
             ++ ": "
-            ++ concreteName
+            ++ prettyMoatType caseTy
             ++ ") : "
             ++ parentName
             ++ "()"
@@ -267,7 +267,7 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
       ++ newlineNonEmpty cases
       ++ prettyCEnumCases indents (map fst cases)
       ++ "}"
-  | allConcrete cases =
+  | otherwise =
     case encodingStyle of
       TaggedFlatObjectStyle ->
         prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
@@ -285,25 +285,9 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
           ++ " {\n"
           ++ prettyTaggedObject name anns cases indents sop
           ++ "\n}"
-  | otherwise =
-    prettyAnnotations Nothing noIndent (dontAddSerializeToEnums anns)
-      ++ "enum class "
-      ++ prettyMoatTypeHeader name tyVars
-      ++ prettyInterfaces ifaces
-      ++ " {"
-      ++ newlineNonEmpty cases
-      ++ prettyEnumCases name indents cases
-      ++ "}"
   where
     isCEnum :: Eq b => [(a, [b])] -> Bool
     isCEnum = all ((== []) . snd)
-
-    allConcrete :: [(a, [(b, MoatType)])] -> Bool
-    allConcrete inp = all isConcrete moatTypes
-      where
-        moatTypes = fmap snd (concatMap snd inp)
-        isConcrete Concrete {} = True
-        isConcrete _ = False
 
     -- because they get it automatically
     dontAddSerializeToEnums :: [Annotation] -> [Annotation]

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -270,7 +270,7 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
   | allConcrete cases =
     case encodingStyle of
       TaggedFlatObjectStyle ->
-        prettyAnnotations Nothing noIndent anns
+        prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
           ++ "sealed class "
           ++ prettyMoatTypeHeader name tyVars
           ++ prettyInterfaces ifaces
@@ -278,7 +278,7 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
         prettyAnnotations
           Nothing
           noIndent
-          (sumAnnotations ++ anns)
+          (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
           ++ "sealed class "
           ++ prettyMoatTypeHeader name tyVars
           ++ prettyInterfaces ifaces
@@ -308,6 +308,10 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
     -- because they get it automatically
     dontAddSerializeToEnums :: [Annotation] -> [Annotation]
     dontAddSerializeToEnums = filter (/= Serializable)
+
+    -- because Parcelize should only be applied to concrete implementations
+    dontAddParcelizeToSealedClasses :: [Annotation] -> [Annotation]
+    dontAddParcelizeToSealedClasses = filter (/= Parcelize)
 
 newlineNonEmpty :: [a] -> String
 newlineNonEmpty [] = ""

--- a/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
@@ -1,0 +1,61 @@
+module SumOfProductWithTaggedObjectAndNonConcreteCasesSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Record0 = Record0
+  { record0Field0 :: Int,
+    record0Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable]
+      }
+  )
+  ''Record0
+
+data Record1 = Record1
+  { record1Field0 :: Int,
+    record1Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable]
+      }
+  )
+  ''Record1
+
+data Enum
+  = DataCons0 [Record0]
+  | DataCons1 [Record1]
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable, SerialName],
+        dataInterfaces = [Parcelable],
+        sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle,
+              sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"],
+              contentsFieldName = "contents"
+            }
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithTaggedObjectAndNonConcreteCasesSpec"
+    it "kotlin" $
+      defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Record0)
+    it "kotlin" $
+      defaultGolden ("kotlinRecord1" <> moduleName) (showKotlin @Record1)
+    it "kotlin" $
+      defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)


### PR DESCRIPTION
In Kotlin, enum classes never have non-static cases, so the encoding for enums with case constructors doesn't make sense and doesn't compile (e.g. [this output](https://github.com/MercuryTechnologies/moat/compare/tad/kotlin-sealed-classes?expand=1#diff-790306aaa456b6b41e19e86efa2bb1bdba91370a67c292d3dc121c8390ddf880)).

To support this, don't restrict sum-of-product encoding to `Concrete` cases, allowing all enums with case constructors to be encoded as `sealed class` regardless of constructor parameter type.

In addition, adding `Parcelize` to the containing `sealed class` doesn't compile; it should only be added to the case implementations. Filter out `Parcelize` for sum-of-product types.