### PR TITLE
Add option to encode enums as value classes in Kotlin

### DIFF
--- a/.golden/kotlinEnumValueClassSpec/golden
+++ b/.golden/kotlinEnumValueClassSpec/golden
@@ -1,0 +1,12 @@
+@Parcelize
+@Serializable
+@JvmInline
+value class EnumAsValueClass(val value: String) : Parcelable {
+    companion object {
+        val First = EnumAsValueClass("first")
+        val Second = EnumAsValueClass("second")
+        val Third = EnumAsValueClass("third")
+
+        val entries = listOf(First, Second, Third)
+    }
+}

--- a/.golden/swiftEnumValueClassSpec/golden
+++ b/.golden/swiftEnumValueClassSpec/golden
@@ -1,0 +1,5 @@
+enum EnumAsValueClass: CaseIterable, Hashable, Codable {
+    case first
+    case second
+    case third
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -73,6 +73,7 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      EnumValueClassSpec
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -34,6 +34,7 @@ prettyKotlinData = \case
       enumTyVars
       enumCases
       enumSumOfProductEncodingOption
+      enumEnumEncodingStyle
       indents
   MoatNewtype {..} ->
     ""
@@ -82,6 +83,41 @@ prettyEnumCases indents = go
           ++ caseName
           ++ ",\n"
           ++ go cases
+
+prettyValueClassInstances :: String -> String -> [String] -> String
+prettyValueClassInstances indents cons enumCases = case enumCases of
+  [] -> ""
+  _ ->
+    indents
+      ++ "companion object {\n"
+      ++ instanceFields enumCases
+      ++ "\n"
+      ++ entriesField enumCases
+      ++ indents
+      ++ "}"
+  where
+    entriesField :: [String] -> String
+    entriesField [] = indents ++ indents ++ "val entries = emptyList()"
+    entriesField _ =
+      indents
+        ++ indents
+        ++ "val entries = listOf("
+        ++ intercalate ", " (map toUpperFirst enumCases)
+        ++ ")\n"
+
+    instanceFields :: [String] -> String
+    instanceFields [] = ""
+    instanceFields (caseName : cases) =
+      indents
+        ++ indents
+        ++ "val "
+        ++ toUpperFirst caseName
+        ++ " = "
+        ++ cons
+        ++ "(\""
+        ++ caseName
+        ++ "\")\n"
+        ++ instanceFields cases
 
 prettyMoatTypeHeader :: String -> [String] -> String
 prettyMoatTypeHeader name [] = name
@@ -166,7 +202,8 @@ prettyApp t1 t2 =
       (args, ret) -> (e1 : args, ret)
     go e1 e2 = ([e1], e2)
 
-{- HLINT ignore prettyTaggedObject "Avoid restricted function" -} -- error is restricted
+{- HLINT ignore prettyTaggedObject "Avoid restricted function" -}
+-- error is restricted
 prettyTaggedObject ::
   String ->
   [Annotation] ->
@@ -218,37 +255,52 @@ prettyEnum ::
   [(String, [(Maybe String, MoatType)])] ->
   -- | encoding style
   SumOfProductEncodingOptions ->
+  -- | enum style
+  EnumEncodingStyle ->
   -- | indents
   String ->
   String
-prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} indents
+prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} ees indents
   | isCEnum cases =
-    prettyAnnotations Nothing noIndent (dontAddSerializeToEnums anns)
-      ++ "enum class "
-      ++ prettyMoatTypeHeader name tyVars
-      ++ prettyInterfaces ifaces
-      ++ " {"
-      ++ newlineNonEmpty cases
-      ++ prettyEnumCases indents (map fst cases)
-      ++ "}"
+      case ees of
+        EnumClassStyle ->
+          prettyAnnotations Nothing noIndent (dontAddSerializeToEnums anns)
+            ++ "enum class "
+            ++ prettyMoatTypeHeader name tyVars
+            ++ prettyInterfaces ifaces
+            ++ " {"
+            ++ newlineNonEmpty cases
+            ++ prettyEnumCases indents (map fst cases)
+            ++ "}"
+        ValueClassStyle ->
+          prettyAnnotations Nothing noIndent (ensureJvmInlineForValueClasses anns)
+            ++ "value class "
+            ++ prettyMoatTypeHeader name tyVars
+            ++ "(val value: String)"
+            ++ prettyInterfaces ifaces
+            ++ " {"
+            ++ newlineNonEmpty cases
+            ++ prettyValueClassInstances indents name (map fst cases)
+            ++ newlineNonEmpty cases
+            ++ "}"
   | otherwise =
-    case encodingStyle of
-      TaggedFlatObjectStyle ->
-        prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
-          ++ "sealed class "
-          ++ prettyMoatTypeHeader name tyVars
-          ++ prettyInterfaces ifaces
-      TaggedObjectStyle ->
-        prettyAnnotations
-          Nothing
-          noIndent
-          (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
-          ++ "sealed class "
-          ++ prettyMoatTypeHeader name tyVars
-          ++ prettyInterfaces ifaces
-          ++ " {\n"
-          ++ prettyTaggedObject name anns cases indents sop
-          ++ "\n}"
+      case encodingStyle of
+        TaggedFlatObjectStyle ->
+          prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
+            ++ "sealed class "
+            ++ prettyMoatTypeHeader name tyVars
+            ++ prettyInterfaces ifaces
+        TaggedObjectStyle ->
+          prettyAnnotations
+            Nothing
+            noIndent
+            (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
+            ++ "sealed class "
+            ++ prettyMoatTypeHeader name tyVars
+            ++ prettyInterfaces ifaces
+            ++ " {\n"
+            ++ prettyTaggedObject name anns cases indents sop
+            ++ "\n}"
   where
     isCEnum :: Eq b => [(a, [b])] -> Bool
     isCEnum = all ((== []) . snd)
@@ -260,6 +312,11 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
     -- because Parcelize should only be applied to concrete implementations
     dontAddParcelizeToSealedClasses :: [Annotation] -> [Annotation]
     dontAddParcelizeToSealedClasses = filter (/= Parcelize)
+
+    ensureJvmInlineForValueClasses :: [Annotation] -> [Annotation]
+    ensureJvmInlineForValueClasses as
+      | JvmInline `elem` as = as
+      | otherwise = as ++ [JvmInline]
 
 newlineNonEmpty :: [a] -> String
 newlineNonEmpty [] = ""

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -7,6 +7,7 @@ module Moat.Types
   ( Annotation (..),
     Backend (..),
     EncodingStyle (..),
+    EnumEncodingStyle (..),
     Interface (..),
     KeepOrDiscard (..),
     MoatData (..),
@@ -181,8 +182,8 @@ data MoatData
         --
         --   Only used by the Swift backend.
         enumTags :: [MoatType],
-        -- |
-        enumSumOfProductEncodingOption :: SumOfProductEncodingOptions
+        enumSumOfProductEncodingOption :: SumOfProductEncodingOptions,
+        enumEnumEncodingStyle :: EnumEncodingStyle
       }
   | -- | A newtype.
     --   Kotlin backend: becomes a value class.
@@ -402,7 +403,8 @@ data Options = Options
     -- determine the rendering style for the sum of products.
     -- The user is responsible for choosing the right options
     -- for the products in a SOP. See 'SumOfProductEncodingOptions'
-    sumOfProductEncodingOptions :: SumOfProductEncodingOptions
+    sumOfProductEncodingOptions :: SumOfProductEncodingOptions,
+    enumEncodingStyle :: EnumEncodingStyle
   }
 
 data SumOfProductEncodingOptions = SumOfProductEncodingOptions
@@ -446,6 +448,16 @@ defaultSumOfProductEncodingOptions =
       contentsFieldName = "contents"
     }
 
+-- | Enum encoding style.
+--
+-- 'EnumClassStyle' will emit a normal enum class.
+--
+-- 'ValueClassStyle' will emit an inline type wrapping a string value,
+-- with static members corresponding to enum cases. This can be useful
+-- for maintaining backward compatibility when adding enum cases.
+data EnumEncodingStyle = EnumClassStyle | ValueClassStyle
+  deriving stock (Eq, Read, Show, Lift)
+
 -- | The default 'Options'.
 --
 -- @
@@ -469,6 +481,7 @@ defaultSumOfProductEncodingOptions =
 --   , makeBase = (False, Nothing, [])
 --   , optionalExpand = False
 --   , sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
+--   , enumEncodingStyle = EnumClassStyle
 --   }
 -- @
 defaultOptions :: Options
@@ -491,7 +504,8 @@ defaultOptions =
       omitCases = const Keep,
       makeBase = (False, Nothing, []),
       optionalExpand = False,
-      sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
+      sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions,
+      enumEncodingStyle = EnumClassStyle
     }
 
 data KeepOrDiscard = Keep | Discard

--- a/test/EnumValueClassSpec.hs
+++ b/test/EnumValueClassSpec.hs
@@ -1,0 +1,31 @@
+module EnumValueClassSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data EnumAsValueClass
+  = First
+  | Second
+  | Third
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable],
+        enumEncodingStyle = ValueClassStyle
+      }
+  )
+  ''EnumAsValueClass
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "EnumValueClassSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @EnumAsValueClass)
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @EnumAsValueClass)

--- a/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
@@ -35,6 +35,7 @@ mobileGenWith
 data Enum
   = DataCons0 [Record0]
   | DataCons1 [Record1]
+
 mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable, SerialName],


### PR DESCRIPTION
Enums can be brittle when using `kotlinx.serialization`, as we saw today in production. While we can rely on default arguments for fields of plain enum types, we can't when decoding collections of enums (e.g. `List<Enum>`), so appending new enum cases can break backward-compatibility with no easy way to handle this on the client side.

An alternative to using `enum class` to represent these types in Kotlin is a `value class` wrapping a `String`, containing static instances corresponding to enum cases. The language will still enforce an `else` case when mapping over these types via `when`, so from the developer perspective this is equivalent to an enum type with a generated `unknown` value. The advantage is that decoding the `value class` type is no longer dependent on decoding one of a static set of values, so enum cases may be added at will without breaking compatibility.

We can support this in Moat by adding an `enumEncodingStyle` option, allowing the user to choose between the traditional `enum class` and `value class` styles for encoding `MoatEnum` data. This is only supported on the Kotlin backend, as I'm not sure what the equivalent is for Swift, or if such a style is desired in that language.