### PR TITLE
Kotlin: Add Parcelable upper bound to type variables

### DIFF
--- a/.golden/kotlinMultipleTypeVariableSpec/golden
+++ b/.golden/kotlinMultipleTypeVariableSpec/golden
@@ -1,0 +1,5 @@
+@Parcelize
+data class Data<A : Parcelable, B : Parcelable>(
+    val field0: A,
+    val field1: B,
+) : Parcelable

--- a/.golden/kotlinTypeVariableSpec/golden
+++ b/.golden/kotlinTypeVariableSpec/golden
@@ -1,4 +1,4 @@
 @Parcelize
-data class Data<A>(
+data class Data<A : Parcelable>(
     val field0: A,
 ) : Parcelable

--- a/.golden/swiftMultipleTypeVariableSpec/golden
+++ b/.golden/swiftMultipleTypeVariableSpec/golden
@@ -1,0 +1,4 @@
+struct Data<A, B>: CaseIterable, Hashable, Codable {
+    let field0: A
+    let field1: B
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -73,6 +73,7 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      MultipleTypeVariableSpec
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -20,7 +20,7 @@ prettyKotlinData = \case
     ""
       ++ prettyAnnotations Nothing noIndent structAnnotations
       ++ "data class "
-      ++ prettyMoatTypeHeader structName structTyVars
+      ++ prettyMoatTypeHeader structName (addTyVarBounds structTyVars structInterfaces)
       ++ "("
       ++ newlineNonEmpty structFields
       ++ prettyStructFields indents structFields
@@ -39,7 +39,7 @@ prettyKotlinData = \case
     ""
       ++ prettyAnnotations Nothing noIndent newtypeAnnotations
       ++ "value class "
-      ++ prettyMoatTypeHeader newtypeName newtypeTyVars
+      ++ prettyMoatTypeHeader newtypeName (addTyVarBounds newtypeTyVars newtypeInterfaces)
       ++ "(val "
       ++ fst newtypeField
       ++ ": "
@@ -236,7 +236,7 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
       TaggedFlatObjectStyle ->
         prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
           ++ "sealed class "
-          ++ prettyMoatTypeHeader name tyVars
+          ++ prettyMoatTypeHeader name (addTyVarBounds tyVars ifaces)
           ++ prettyInterfaces ifaces
       TaggedObjectStyle ->
         prettyAnnotations
@@ -244,7 +244,7 @@ prettyEnum anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..} in
           noIndent
           (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
           ++ "sealed class "
-          ++ prettyMoatTypeHeader name tyVars
+          ++ prettyMoatTypeHeader name (addTyVarBounds tyVars ifaces)
           ++ prettyInterfaces ifaces
           ++ " {\n"
           ++ prettyTaggedObject name anns cases indents sop
@@ -272,3 +272,8 @@ toUpperFirst = \case
 
 noIndent :: String
 noIndent = ""
+
+addTyVarBounds :: [String] -> [Interface] -> [String]
+addTyVarBounds tyVars ifaces
+  | Parcelable `elem` ifaces = map (++ " : Parcelable") tyVars
+  | otherwise = tyVars

--- a/test/MultipleTypeVariableSpec.hs
+++ b/test/MultipleTypeVariableSpec.hs
@@ -1,0 +1,26 @@
+module MultipleTypeVariableSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+
+data Data a b = Data { field0 :: a, field1 :: b }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize],
+        dataInterfaces = [Parcelable],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      }
+  )
+  ''Data
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "MultipleTypeVariableSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @(Data _ _))
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @(Data _ _))


### PR DESCRIPTION
Yet another quirk with `Parcelable`: all field types must also implement `Parcelable`.

Add the `: Parcelable` upper bound to generic type variables to satisfy this constraint.