### PR TITLE
Kotlin: Add option to encode enums as value classes

### DIFF
--- a/.golden/kotlinEnumValueClassSpec/golden
+++ b/.golden/kotlinEnumValueClassSpec/golden
@@ -1,0 +1,16 @@
+@Parcelize
+@Serializable
+@JvmInline
+value class EnumAsValueClass(val value: String) : Parcelable {
+    companion object {
+        val First: EnumAsValueClass = EnumAsValueClass("first")
+        val Second: EnumAsValueClass = EnumAsValueClass("second")
+        val Third: EnumAsValueClass = EnumAsValueClass("third")
+
+        val entries: List<EnumAsValueClass> = listOf(
+            First,
+            Second,
+            Third,
+        )
+    }
+}

--- a/.golden/swiftEnumValueClassSpec/golden
+++ b/.golden/swiftEnumValueClassSpec/golden
@@ -1,0 +1,5 @@
+enum EnumAsValueClass: CaseIterable, Hashable, Codable {
+    case first
+    case second
+    case third
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -73,6 +73,7 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      EnumValueClassSpec
       MultipleTypeVariableSpec
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -7,6 +7,7 @@ module Moat.Types
   ( Annotation (..),
     Backend (..),
     EncodingStyle (..),
+    EnumEncodingStyle (..),
     Interface (..),
     KeepOrDiscard (..),
     MoatData (..),
@@ -181,8 +182,8 @@ data MoatData
         --
         --   Only used by the Swift backend.
         enumTags :: [MoatType],
-        -- |
-        enumSumOfProductEncodingOption :: SumOfProductEncodingOptions
+        enumSumOfProductEncodingOption :: SumOfProductEncodingOptions,
+        enumEnumEncodingStyle :: EnumEncodingStyle
       }
   | -- | A newtype.
     --   Kotlin backend: becomes a value class.
@@ -402,7 +403,15 @@ data Options = Options
     -- determine the rendering style for the sum of products.
     -- The user is responsible for choosing the right options
     -- for the products in a SOP. See 'SumOfProductEncodingOptions'
-    sumOfProductEncodingOptions :: SumOfProductEncodingOptions
+    sumOfProductEncodingOptions :: SumOfProductEncodingOptions,
+    -- | Enum encoding style.
+    --
+    --   Only applies for a "C-style" sum-of-products type, where
+    --   each sum constructor has zero type arguments. See
+    --   'EnumEncodingStyle'.
+    --
+    --   This option is only meaningful on the Kotlin backend.
+    enumEncodingStyle :: EnumEncodingStyle
   }
 
 data SumOfProductEncodingOptions = SumOfProductEncodingOptions
@@ -446,6 +455,16 @@ defaultSumOfProductEncodingOptions =
       contentsFieldName = "contents"
     }
 
+-- | Enum encoding style.
+--
+-- 'EnumClassStyle' will emit a normal enum class.
+--
+-- 'ValueClassStyle' will emit an inline type wrapping a string value,
+-- with static members corresponding to enum cases. This can be useful
+-- for maintaining backward compatibility when adding enum cases.
+data EnumEncodingStyle = EnumClassStyle | ValueClassStyle
+  deriving stock (Eq, Read, Show, Lift)
+
 -- | The default 'Options'.
 --
 -- @
@@ -469,6 +488,7 @@ defaultSumOfProductEncodingOptions =
 --   , makeBase = (False, Nothing, [])
 --   , optionalExpand = False
 --   , sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
+--   , enumEncodingStyle = EnumClassStyle
 --   }
 -- @
 defaultOptions :: Options
@@ -491,7 +511,8 @@ defaultOptions =
       omitCases = const Keep,
       makeBase = (False, Nothing, []),
       optionalExpand = False,
-      sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
+      sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions,
+      enumEncodingStyle = EnumClassStyle
     }
 
 data KeepOrDiscard = Keep | Discard

--- a/test/EnumValueClassSpec.hs
+++ b/test/EnumValueClassSpec.hs
@@ -1,0 +1,31 @@
+module EnumValueClassSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data EnumAsValueClass
+  = First
+  | Second
+  | Third
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable],
+        enumEncodingStyle = ValueClassStyle
+      }
+  )
+  ''EnumAsValueClass
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "EnumValueClassSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @EnumAsValueClass)
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @EnumAsValueClass)


### PR DESCRIPTION
## Changes

Add an `enumEncodingStyle` option to allow the user to generate either an `enum class` or `value class` using the Kotlin backend.

## Background

We currently have some fairly complicated serialization machinery to deal with "unknown" enum cases:

- Massage `MoatData` to include an additional `unknown` case.
- On the Android side, a custom serializer which falls back to this unknown case for unrecognized case names in the JSON.
- Generate instances of this serializer for each enum type, because Kotlin enum classes are completely static, so we must inform the serializer of each field we should recognize.

An example of the resulting Kotlin code:

```kotlin
@Serializable(with = TransactionStatusSerializer::class)
@Parcelize
enum class TransactionStatus : Parcelable {
    pending,
    created,
    sent,
    cancelled,
    failed,
    alertFailed,
    deleted,
    holdReleased,
    pendingApproval,
    unknown,
}

internal object TransactionStatusSerializer : EnumSerializer<TransactionStatus>(
    TransactionStatus::class,
    listOf(
        TransactionStatus.pending,
        TransactionStatus.created,
        TransactionStatus.sent,
        TransactionStatus.cancelled,
        TransactionStatus.failed,
        TransactionStatus.alertFailed,
        TransactionStatus.deleted,
        TransactionStatus.holdReleased,
        TransactionStatus.pendingApproval,
    ),
    TransactionStatus.unknown
)
```

Pretty much all of this can be removed if we generated "value classes" (the Kotlin equivalent of `newtype`) instead. For example:

```kotlin
@Parcelize
@Serializable
@JvmInline
value class TransactionStatus(val value: String) : Parcelable {
    companion object {
        val Pending: TransactionStatus = TransactionStatus("pending")
        val Created: TransactionStatus = TransactionStatus("created")
        // ...

        val entries: List<TransactionStatus> = listOf(
            Pending,
            Created,
            // ...
        )
    }
}
```

This construct retains the positive qualities of enum classes:
- "exhaustive `when`" behavior, by replacing `unknown ->` with `else ->`
- enumeration of known cases (via the generated `entries` field)

But it has the advantage of being decodable by the default serialization config while implicitly handling unknown case names.

