### PR TITLE
Generate documentation comments from Haddock

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v19
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,20 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6"]
+        cabal: ["3.8"]
         ghc: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.4", "9.4.2"]
     env:
       CONFIG: "--enable-tests"
     steps:
-      - uses: actions/checkout@v2
-      - uses: haskell/actions/setup@v1
+      - uses: actions/checkout@v3
+      - uses: haskell/actions/setup@v2.3
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
@@ -38,4 +38,3 @@ jobs:
       - run: cabal v2-test --disable-optimization -j $CONFIG
       - run: cabal v2-haddock -j $CONFIG
       - run: cabal v2-sdist
-

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,7 +19,7 @@ jobs:
           - ghc942
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v14
+    - uses: cachix/install-nix-action@v19
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.golden/kotlinBasicDocSpec/golden
+++ b/.golden/kotlinBasicDocSpec/golden
@@ -1,35 +1,35 @@
 /**
  * # Heading
- * 
+ *
  * ## *Second-level heading, italic*
- * 
+ *
  * Paragraphs of documentation for the [Data] type. This line should wrap according to your
  * preference.
- * 
+ *
  * Some additional markup: *emphasis*, **bold**, `monospaced`.
- * 
+ *
  * ### **Lists**
- * 
+ *
  * Unordered
- * 
+ *
  *   - Unordered item
  *   - Second unordered item
  *   - Third unordered item
- * 
+ *
  * Ordered
- * 
+ *
  * 1.  Ordered item
  * 2.  Second ordrered item
  * 3.  Third ordered item
- * 
+ *
  * ## Code block
- * 
+ *
  *     func fibonacci(_ n: Int) -> Int {
  *         guard n != 0, n != 1 else { return n }
  *         return fibonacci(n - 1) + fibonacci(n - 2)
  *     }
- * 
- * @param first First field, it's an Int  
+ *
+ * @param first First field, it's an Int
  * @param second Second field, it's maybe an Int
  */
 data class Data(

--- a/.golden/kotlinBasicDocSpec/golden
+++ b/.golden/kotlinBasicDocSpec/golden
@@ -1,0 +1,38 @@
+/**
+ * # Heading
+ * 
+ * ## *Second-level heading, italic*
+ * 
+ * Paragraphs of documentation for the [Data] type. This line should wrap according to your
+ * preference.
+ * 
+ * Some additional markup: *emphasis*, **bold**, `monospaced`.
+ * 
+ * ### **Lists**
+ * 
+ * Unordered
+ * 
+ *   - Unordered item
+ *   - Second unordered item
+ *   - Third unordered item
+ * 
+ * Ordered
+ * 
+ * 1.  Ordered item
+ * 2.  Second ordrered item
+ * 3.  Third ordered item
+ * 
+ * ## Code block
+ * 
+ *     func fibonacci(_ n: Int) -> Int {
+ *         guard n != 0, n != 1 else { return n }
+ *         return fibonacci(n - 1) + fibonacci(n - 2)
+ *     }
+ * 
+ * @param first First field, it's an Int  
+ * @param second Second field, it's maybe an Int
+ */
+data class Data(
+    val first: Int,
+    val second: Int? = null,
+)

--- a/.golden/kotlinEnumSumOfProductDocSpec/golden
+++ b/.golden/kotlinEnumSumOfProductDocSpec/golden
@@ -1,0 +1,16 @@
+/** Top-level documentation describing [Enum]. */
+@JsonClassDiscriminator("tag")
+@Serializable
+sealed class Enum : Parcelable {
+    /** A constructor. */
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons0")
+    data class DataCons0(val contents: Record0) : Enum()
+
+    /** Another constructor. */
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons1")
+    data class DataCons1(val contents: Record1) : Enum()
+}

--- a/.golden/kotlinEnumValueClassDocSpec/golden
+++ b/.golden/kotlinEnumValueClassDocSpec/golden
@@ -1,0 +1,20 @@
+/** Top-level enum documentation. */
+@Parcelize
+@Serializable
+@JvmInline
+value class EnumAsValueClass(val value: String) : Parcelable {
+    companion object {
+        /** [First] */
+        val First: EnumAsValueClass = EnumAsValueClass("first")
+        /** [Second] */
+        val Second: EnumAsValueClass = EnumAsValueClass("second")
+        /** [Third] */
+        val Third: EnumAsValueClass = EnumAsValueClass("third")
+
+        val entries: List<EnumAsValueClass> = listOf(
+            First,
+            Second,
+            Third,
+        )
+    }
+}

--- a/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
@@ -1,6 +1,6 @@
 /**
  * Record 0 with duplicate fields
- * 
+ *
  * @param field1 not a duplicate
  */
 data class Data0(

--- a/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
@@ -1,0 +1,9 @@
+/**
+ * Record 0 with duplicate fields
+ * 
+ * @param field1 not a duplicate
+ */
+data class Data0(
+    val field0: Int,
+    val field1: Int? = null,
+)

--- a/.golden/kotlinRecord0SumOfProductDocSpec/golden
+++ b/.golden/kotlinRecord0SumOfProductDocSpec/golden
@@ -1,7 +1,7 @@
 /**
  * Documentation for [Record0].
- * 
- * @param record0Field0 The zeroth field of record 0  
+ *
+ * @param record0Field0 The zeroth field of record 0
  * @param record0Field1 The first field of record 0
  */
 @Parcelize

--- a/.golden/kotlinRecord0SumOfProductDocSpec/golden
+++ b/.golden/kotlinRecord0SumOfProductDocSpec/golden
@@ -1,0 +1,12 @@
+/**
+ * Documentation for [Record0].
+ * 
+ * @param record0Field0 The zeroth field of record 0  
+ * @param record0Field1 The first field of record 0
+ */
+@Parcelize
+@Serializable
+data class Record0(
+    val record0Field0: Int,
+    val record0Field1: Int,
+) : Enum()

--- a/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
@@ -1,6 +1,6 @@
 /**
  * Record 1 with duplicate fields
- * 
+ *
  * @param field2 not a duplicate
  */
 data class Data1(

--- a/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
@@ -1,0 +1,9 @@
+/**
+ * Record 1 with duplicate fields
+ * 
+ * @param field2 not a duplicate
+ */
+data class Data1(
+    val field0: String,
+    val field2: String? = null,
+)

--- a/.golden/kotlinRecord1SumOfProductDocSpec/golden
+++ b/.golden/kotlinRecord1SumOfProductDocSpec/golden
@@ -1,7 +1,7 @@
 /**
  * Documentation for [Record1].
- * 
- * @param record1Field0 The zeroth field of record 1  
+ *
+ * @param record1Field0 The zeroth field of record 1
  * @param record1Field1 The first field of record 1
  */
 @Parcelize

--- a/.golden/kotlinRecord1SumOfProductDocSpec/golden
+++ b/.golden/kotlinRecord1SumOfProductDocSpec/golden
@@ -1,0 +1,12 @@
+/**
+ * Documentation for [Record1].
+ * 
+ * @param record1Field0 The zeroth field of record 1  
+ * @param record1Field1 The first field of record 1
+ */
+@Parcelize
+@Serializable
+data class Record1(
+    val record1Field0: Int,
+    val record1Field1: Int,
+) : Enum()

--- a/.golden/swiftBasicDocSpec/golden
+++ b/.golden/swiftBasicDocSpec/golden
@@ -1,0 +1,37 @@
+/// # Heading
+/// 
+/// ## *Second-level heading, italic*
+/// 
+/// Paragraphs of documentation for the ``Data`` type. This line should wrap according to your
+/// preference.
+/// 
+/// Some additional markup: *emphasis*, **bold**, `monospaced`.
+/// 
+/// ### **Lists**
+/// 
+/// Unordered
+/// 
+///   - Unordered item
+///   - Second unordered item
+///   - Third unordered item
+/// 
+/// Ordered
+/// 
+/// 1.  Ordered item
+/// 2.  Second ordrered item
+/// 3.  Third ordered item
+/// 
+/// ## Code block
+/// 
+///     func fibonacci(_ n: Int) -> Int {
+///         guard n != 0, n != 1 else { return n }
+///         return fibonacci(n - 1) + fibonacci(n - 2)
+///     }
+/// 
+///   - Parameters:
+///       - first: First field, it's an Int
+///       - second: Second field, it's maybe an Int
+struct Data {
+    let first: Int
+    let second: Int?
+}

--- a/.golden/swiftBasicDocSpec/golden
+++ b/.golden/swiftBasicDocSpec/golden
@@ -27,11 +27,9 @@
 ///         guard n != 0, n != 1 else { return n }
 ///         return fibonacci(n - 1) + fibonacci(n - 2)
 ///     }
-/// 
-///   - Parameters:
-///       - first: First field, it's an Int
-///       - second: Second field, it's maybe an Int
 struct Data {
+    /// First field, it's an Int
     let first: Int
+    /// Second field, it's maybe an Int
     let second: Int?
 }

--- a/.golden/swiftBasicDocSpec/golden
+++ b/.golden/swiftBasicDocSpec/golden
@@ -1,28 +1,28 @@
 /// # Heading
-/// 
+///
 /// ## *Second-level heading, italic*
-/// 
+///
 /// Paragraphs of documentation for the ``Data`` type. This line should wrap according to your
 /// preference.
-/// 
+///
 /// Some additional markup: *emphasis*, **bold**, `monospaced`.
-/// 
+///
 /// ### **Lists**
-/// 
+///
 /// Unordered
-/// 
+///
 ///   - Unordered item
 ///   - Second unordered item
 ///   - Third unordered item
-/// 
+///
 /// Ordered
-/// 
+///
 /// 1.  Ordered item
 /// 2.  Second ordrered item
 /// 3.  Third ordered item
-/// 
+///
 /// ## Code block
-/// 
+///
 ///     func fibonacci(_ n: Int) -> Int {
 ///         guard n != 0, n != 1 else { return n }
 ///         return fibonacci(n - 1) + fibonacci(n - 2)

--- a/.golden/swiftEnumSumOfProductDocSpec/golden
+++ b/.golden/swiftEnumSumOfProductDocSpec/golden
@@ -1,0 +1,7 @@
+/// Top-level documentation describing ``Enum``.
+enum Enum: CaseIterable, Hashable, Codable {
+    /// A constructor.
+    case dataCons0(Record0)
+    /// Another constructor.
+    case dataCons1(Record1)
+}

--- a/.golden/swiftEnumValueClassDocSpec/golden
+++ b/.golden/swiftEnumValueClassDocSpec/golden
@@ -1,0 +1,9 @@
+/// Top-level enum documentation.
+enum EnumAsValueClass: CaseIterable, Hashable, Codable {
+    /// ``First``
+    case first
+    /// ``Second``
+    case second
+    /// ``Third``
+    case third
+}

--- a/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
@@ -1,0 +1,6 @@
+/// Record 0 with duplicate fields
+struct Data0 {
+    let field0: Int
+    /// not a duplicate
+    let field1: Int?
+}

--- a/.golden/swiftRecord0SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord0SumOfProductDocSpec/golden
@@ -1,0 +1,9 @@
+/// Documentation for ``Record0``.
+/// 
+///   - Parameters:
+///       - record0Field0: The zeroth field of record 0
+///       - record0Field1: The first field of record 0
+struct Record0: CaseIterable, Hashable, Codable {
+    let record0Field0: Int
+    let record0Field1: Int
+}

--- a/.golden/swiftRecord0SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord0SumOfProductDocSpec/golden
@@ -1,9 +1,7 @@
 /// Documentation for ``Record0``.
-/// 
-///   - Parameters:
-///       - record0Field0: The zeroth field of record 0
-///       - record0Field1: The first field of record 0
 struct Record0: CaseIterable, Hashable, Codable {
+    /// The zeroth field of record 0
     let record0Field0: Int
+    /// The first field of record 0
     let record0Field1: Int
 }

--- a/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
@@ -1,0 +1,6 @@
+/// Record 1 with duplicate fields
+struct Data1 {
+    let field0: String
+    /// not a duplicate
+    let field2: String?
+}

--- a/.golden/swiftRecord1SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord1SumOfProductDocSpec/golden
@@ -1,9 +1,7 @@
 /// Documentation for ``Record1``.
-/// 
-///   - Parameters:
-///       - record1Field0: The zeroth field of record 1
-///       - record1Field1: The first field of record 1
 struct Record1: CaseIterable, Hashable, Codable {
+    /// The zeroth field of record 1
     let record1Field0: Int
+    /// The first field of record 1
     let record1Field1: Int
 }

--- a/.golden/swiftRecord1SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord1SumOfProductDocSpec/golden
@@ -1,0 +1,9 @@
+/// Documentation for ``Record1``.
+/// 
+///   - Parameters:
+///       - record1Field0: The zeroth field of record 1
+///       - record1Field1: The first field of record 1
+struct Record1: CaseIterable, Hashable, Codable {
+    let record1Field0: Int
+    let record1Field1: Int
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666634325,
-        "narHash": "sha256-0PYdi0HDNasagoOrLv6LOXh2J++T+TnsDg8S/naJGDk=",
+        "lastModified": 1675942811,
+        "narHash": "sha256-/v4Z9mJmADTpXrdIlAjFa1e+gkpIIROR670UVDQFwIw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "969c3ccf30a6cf8f7d431f097743a491b0eda4f7",
+        "rev": "724bfc0892363087709bd3a5a1666296759154b1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Generate swift and kotlin types from haskell types";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
   outputs = {
@@ -40,7 +40,6 @@
         inherit
           (pkgs.haskell.lib)
           dontCheck
-          doJailbreak
           overrideCabal
           ;
         inherit
@@ -63,50 +62,7 @@
           };
           ghc942 = hself: hsuper: {
             # https://github.com/NixOS/nixpkgs/issues/140774
-            ghcid = enableSeparateBinOutput hsuper.ghcid;
-            hspec-contrib = dontCheck hsuper.hspec-contrib;
-            hlint = hself.callHackage "hlint" "3.5" {};
-            # Get rid of this once fourmolu supports GHC 9.4.
-            fourmolu =
-              appendPatches
-              [
-                # The GHC 9.4 pull request builds upon these unpublished changes,
-                # which is why we include them.
-                #
-                # Also, there is no PR for these changes.  The fourmolu maintainers
-                # apparently commit straight to master...
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/commit/2c11f555945e755cc6e805de482404d5484d53b6.patch";
-                  sha256 = "sha256-bWJxOYQoLtsW7KaVbTxIxX+cFx9x3ekEmbA9NuJ3qtk=";
-                })
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/commit/8eb7ef82676ab3bff9b249c74fc5d81dc23a2657.patch";
-                  sha256 = "sha256-rlKDRv27EGnlStNiKEniZiKSib1Zr9E3hGT3QuU5xLI=";
-                })
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/commit/14b1bc832716edaf4239c4e364836185f0aa816b.patch";
-                  sha256 = "sha256-cfXh6ufxASbg2wXp/5ixfUNSC54O/eq8hx88lZKAJ18=";
-                })
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/commit/e7fc4ec52aeeb50b3a886d1f55f4468ae6d46a46.patch";
-                  sha256 = "sha256-d+hg/mOEAybq461VLkmCrwtFyHgX8Q+715yaJXHn7/g=";
-                })
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/commit/809256014cb6f65d8cd3447c0502493f57d3e307.patch";
-                  sha256 = "sha256-FdVj9MidRCfMUERVWvFV9k2rnvnorxJE7NpehNBQ8OQ=";
-                })
-
-                # The actual change to support GHC 9.4
-                (pkgs.fetchpatch {
-                  url = "https://github.com/fourmolu/fourmolu/pull/242.patch";
-                  sha256 = "sha256-mWMtG+pkiNzmkXWVZhIILhhnPzQM070o6+hwyNZkY+0=";
-                  includes = ["data/*" "src/*" "tests/*" "fourmolu.cabal"];
-                })
-              ]
-              (doJailbreak hsuper.fourmolu_0_8_2_0);
-            newtype-generics = doJailbreak hsuper.newtype-generics;
-            conduit-extra = dontCheck hsuper.conduit-extra;
-            hls-code-range-plugin = dontCheck hsuper.hls-code-range-plugin;
+            ghcid = dontCheck (enableSeparateBinOutput hsuper.ghcid);
           };
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -42,10 +42,6 @@
           dontCheck
           overrideCabal
           ;
-        inherit
-          (pkgs.haskell.lib.compose)
-          appendPatches
-          ;
 
         enableSeparateBinOutput = drv:
           if (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64)
@@ -54,6 +50,10 @@
 
         haskellOverlays = {
           ghc902 = hself: hsuper: {
+            # Wants cabal == 3.6
+            fourmolu = hsuper.fourmolu.overrideScope (lself: lsuper: {
+              Cabal = lself.Cabal_3_6_3_0;
+            });
           };
           ghc924 = hself: hsuper: {
             # https://github.com/NixOS/nixpkgs/issues/140774

--- a/moat.cabal
+++ b/moat.cabal
@@ -79,6 +79,7 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      DuplicateRecordFieldSpec
       EnumValueClassDocSpec
       EnumValueClassSpec
       MultipleTypeVariableSpec

--- a/moat.cabal
+++ b/moat.cabal
@@ -109,7 +109,7 @@ test-suite spec
       ScopedTypeVariables
       TemplateHaskell
       TypeApplications
-  ghc-options: -Wall -Wno-unused-top-binds
+  ghc-options: -Wall -Wno-unused-top-binds -haddock
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:

--- a/moat.cabal
+++ b/moat.cabal
@@ -47,7 +47,7 @@ library
     , containers >=0.5.9 && <0.7
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.11 && <2.20
+    , template-haskell >=2.18 && <2.20
     , text >=1.2 && <2.1
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2
@@ -111,7 +111,7 @@ test-suite spec
     , hspec-golden
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.11 && <2.20
+    , template-haskell >=2.18 && <2.20
     , text >=1.2 && <2.1
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -28,6 +28,9 @@ library
       Moat
   other-modules:
       Moat.Class
+      Moat.Pretty.Doc.DocC
+      Moat.Pretty.Doc.KDoc
+      Moat.Pretty.Doc.Markdown
       Moat.Pretty.Kotlin
       Moat.Pretty.Swift
       Moat.Types
@@ -44,10 +47,12 @@ library
       base >=4.11 && <4.18
     , bytestring >=0.10 && <0.12
     , case-insensitive ==1.2.*
+    , cmark-gfm >=0.2.5 && <0.3.0
     , containers >=0.5.9 && <0.7
+    , haddock-library >=1.10 && <1.12
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.18 && <2.20
+    , template-haskell >=2.11 && <2.20
     , text >=1.2 && <2.1
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2
@@ -66,6 +71,7 @@ test-suite spec
       AdvancedNewtypeSpec
       AdvancedNewtypeWithEnumFieldSpec
       AdvancedRecordSpec
+      BasicDocSpec
       BasicEnumSpec
       BasicEnumWithRawValueSpec
       BasicNewtypeSpec
@@ -73,8 +79,10 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      EnumValueClassDocSpec
       EnumValueClassSpec
       MultipleTypeVariableSpec
+      SumOfProductDocSpec
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec
@@ -83,6 +91,9 @@ test-suite spec
       TypeVariableSpec
       Moat
       Moat.Class
+      Moat.Pretty.Doc.DocC
+      Moat.Pretty.Doc.KDoc
+      Moat.Pretty.Doc.Markdown
       Moat.Pretty.Kotlin
       Moat.Pretty.Swift
       Moat.Types
@@ -105,13 +116,15 @@ test-suite spec
       base >=4.11 && <4.18
     , bytestring >=0.10 && <0.12
     , case-insensitive ==1.2.*
+    , cmark-gfm >=0.2.5 && <0.3.0
     , containers >=0.5.9 && <0.7
+    , haddock-library >=1.10 && <1.12
     , hspec
     , hspec-discover
     , hspec-golden
     , mtl ==2.2.*
     , primitive >=0.6.4 && <0.8
-    , template-haskell >=2.18 && <2.20
+    , template-haskell >=2.11 && <2.20
     , text >=1.2 && <2.1
     , th-abstraction >=0.3 && <0.5
     , th-compat >=0.1.0 && <0.2

--- a/moat.nix
+++ b/moat.nix
@@ -1,25 +1,25 @@
-{ mkDerivation, base, bytestring, case-insensitive, containers
-, hpack, hspec, hspec-discover, hspec-golden, lib, mtl, primitive
-, template-haskell, text, th-abstraction, th-compat, time
-, unordered-containers, uuid-types, vector
+{ mkDerivation, base, bytestring, case-insensitive, cmark-gfm
+, containers, haddock-library, hspec, hspec-discover, hspec-golden
+, lib, mtl, primitive, template-haskell, text, th-abstraction
+, th-compat, time, unordered-containers, uuid-types, vector
 }:
 mkDerivation {
   pname = "moat";
   version = "0.1";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring case-insensitive containers mtl primitive
+    base bytestring case-insensitive cmark-gfm containers
+    haddock-library mtl primitive template-haskell text th-abstraction
+    th-compat time unordered-containers uuid-types vector
+  ];
+  libraryToolDepends = [ hspec-discover ];
+  testHaskellDepends = [
+    base bytestring case-insensitive cmark-gfm containers
+    haddock-library hspec hspec-discover hspec-golden mtl primitive
     template-haskell text th-abstraction th-compat time
     unordered-containers uuid-types vector
   ];
-  libraryToolDepends = [ hpack hspec-discover ];
-  testHaskellDepends = [
-    base bytestring case-insensitive containers hspec hspec-discover
-    hspec-golden mtl primitive template-haskell text th-abstraction
-    th-compat time unordered-containers uuid-types vector
-  ];
   testToolDepends = [ hspec-discover ];
-  prePatch = "hpack";
   homepage = "https://github.com/chessai/moat#readme";
   description = "Generate swift and kotlin types from haskell types";
   license = lib.licenses.mit;

--- a/package.yaml
+++ b/package.yaml
@@ -19,10 +19,12 @@ dependencies:
   - base >= 4.11 && < 4.18
   - bytestring >= 0.10 && < 0.12
   - case-insensitive >= 1.2 && < 1.3
+  - cmark-gfm >= 0.2.5 && < 0.3.0
   - containers >= 0.5.9 && < 0.7
+  - haddock-library >= 1.10 && < 1.12
   - mtl >= 2.2 && < 2.3
   - primitive >= 0.6.4 && < 0.8
-  - template-haskell >= 2.18 && < 2.20
+  - template-haskell >= 2.11 && < 2.20
   - text >= 1.2 && < 2.1
   - th-abstraction >= 0.3 && < 0.5
   - th-compat >= 0.1.0 && < 0.2

--- a/package.yaml
+++ b/package.yaml
@@ -59,3 +59,4 @@ tests:
       - TypeApplications
     ghc-options:
       -Wno-unused-top-binds
+      -haddock

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,7 @@ dependencies:
   - containers >= 0.5.9 && < 0.7
   - mtl >= 2.2 && < 2.3
   - primitive >= 0.6.4 && < 0.8
-  - template-haskell >= 2.11 && < 2.20
+  - template-haskell >= 2.18 && < 2.20
   - text >= 1.2 && < 2.1
   - th-abstraction >= 0.3 && < 0.5
   - th-compat >= 0.1.0 && < 0.2

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -39,6 +39,8 @@ module Moat
     Protocol (..),
     Interface (..),
     Annotation (..),
+    Field (..),
+    EnumCase (..),
 
     -- * Options for encoding types
 

--- a/src/Moat/Pretty/Doc/DocC.hs
+++ b/src/Moat/Pretty/Doc/DocC.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Moat.Pretty.Doc.DocC
+  ( prettyDoc,
+    prettyDocComment,
+    prettyFieldDoc
+  )
+where
+
+import Moat.Pretty.Doc.Markdown
+import Moat.Types (Field (..))
+import CMarkGFM (nodeToCommonmark, Node (..))
+import qualified Data.Text as T
+import Data.Maybe (mapMaybe)
+
+prettyDocComment :: String -> String -> String
+prettyDocComment indents str = concatMap (\s -> indents ++ "/// " ++ s ++ "\n") (lines str)
+
+-- | Format Haddock documentation as Markdown, wrapping at the
+-- given column.
+prettyDoc :: Int -> String -> String
+prettyDoc wrap haddock =
+  let
+    cmark = markdown text identifier (parseDoc haddock)
+    docstr = nodeToCommonmark [] (Just wrap) cmark
+  in T.unpack docstr
+
+prettyFieldDoc :: Int -> [Field] -> Maybe String
+prettyFieldDoc wrap fields =
+  let
+    items = mapMaybe paramDoc fields
+    cmark = case items of
+      [] -> Nothing
+      _ -> Just $
+             ul [li [para [text "Parameters:"], ul items]]
+  in T.unpack . nodeToCommonmark [] (Just wrap) <$> cmark
+
+paramDoc :: Field -> Maybe Node
+paramDoc Field { fieldDoc = Nothing } = Nothing
+paramDoc Field { fieldName = name, fieldDoc = Just doc } =
+  let
+    prefix = name ++ ": "
+    cmark = markdown text identifier (parseDoc doc)
+  in Just $ li [ para (text prefix : inlineContent cmark) ]
+
+identifier :: String -> Node
+identifier ident = inline "``" "``" [text ident]

--- a/src/Moat/Pretty/Doc/DocC.hs
+++ b/src/Moat/Pretty/Doc/DocC.hs
@@ -7,14 +7,17 @@ module Moat.Pretty.Doc.DocC
   )
 where
 
+import CMarkGFM (nodeToCommonmark, Node (..))
+import Data.Char (isSpace)
+import Data.List (dropWhileEnd)
+import Data.Maybe (mapMaybe)
+import qualified Data.Text as T
 import Moat.Pretty.Doc.Markdown
 import Moat.Types (Field (..))
-import CMarkGFM (nodeToCommonmark, Node (..))
-import qualified Data.Text as T
-import Data.Maybe (mapMaybe)
 
 prettyDocComment :: String -> String -> String
-prettyDocComment indents str = concatMap (\s -> indents ++ "/// " ++ s ++ "\n") (lines str)
+prettyDocComment indents str =
+  concatMap (\s -> dropWhileEnd isSpace (indents ++ "/// " ++ s) ++ "\n") (lines str)
 
 -- | Format Haddock documentation as Markdown, wrapping at the
 -- given column.

--- a/src/Moat/Pretty/Doc/KDoc.hs
+++ b/src/Moat/Pretty/Doc/KDoc.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Moat.Pretty.Doc.KDoc
+  ( prettyDoc,
+    prettyDocComment,
+    prettyFieldDoc,
+  )
+where
+
+import Moat.Pretty.Doc.Markdown
+import Moat.Types (Field (..))
+import CMarkGFM (nodeToCommonmark, Node (..))
+import qualified Data.Text as T
+import Data.List (intercalate)
+
+prettyDocComment :: Int -> String -> String -> String
+prettyDocComment wrap indents str =
+  let ls = lines str
+  in case ls of
+  [] -> ""
+  [l] -> if length l + length indents < wrap then short l else long ls
+  _ -> long ls
+  where
+    short :: String -> String
+    short l = indents ++ "/** " ++ l ++ " */\n"
+
+    long :: [String] -> String
+    long ls =
+      indents
+        ++ "/**\n"
+        ++ concatMap (\s -> indents ++ " * " ++ s ++ "\n") ls
+        ++ indents
+        ++ " */\n"
+
+prettyDoc :: Int -> String -> String
+prettyDoc wrap haddock =
+  let
+    cmark = markdown text identifier (parseDoc haddock)
+    docstr = nodeToCommonmark [] (Just wrap) cmark
+  in T.unpack docstr
+
+prettyFieldDoc :: Int -> [Field] -> Maybe String
+prettyFieldDoc wrap fields =
+  let
+    params = filter (/= []) (map fieldParam fields)
+    cmark = case params of
+      [] -> Nothing
+      _ -> Just $ para (intercalate [br] params)
+  in T.unpack . nodeToCommonmark [] (Just wrap) <$> cmark
+
+fieldParam :: Field -> [Node]
+fieldParam Field {fieldDoc = Nothing} = []
+fieldParam Field {fieldDoc = Just doc, ..}
+  = text ("@param " ++ fieldName ++ " ") : inlineContent (markdown text identifier (parseDoc doc))
+
+identifier :: String -> Node
+identifier ident = inline "[" "]" [text ident]

--- a/src/Moat/Pretty/Doc/KDoc.hs
+++ b/src/Moat/Pretty/Doc/KDoc.hs
@@ -7,11 +7,12 @@ module Moat.Pretty.Doc.KDoc
   )
 where
 
+import CMarkGFM (nodeToCommonmark, Node (..))
+import Data.Char (isSpace)
+import Data.List (intercalate, dropWhileEnd)
+import qualified Data.Text as T
 import Moat.Pretty.Doc.Markdown
 import Moat.Types (Field (..))
-import CMarkGFM (nodeToCommonmark, Node (..))
-import qualified Data.Text as T
-import Data.List (intercalate)
 
 prettyDocComment :: Int -> String -> String -> String
 prettyDocComment wrap indents str =
@@ -28,7 +29,7 @@ prettyDocComment wrap indents str =
     long ls =
       indents
         ++ "/**\n"
-        ++ concatMap (\s -> indents ++ " * " ++ s ++ "\n") ls
+        ++ concatMap (\s -> dropWhileEnd isSpace (indents ++ " * " ++ s) ++ "\n") ls
         ++ indents
         ++ " */\n"
 

--- a/src/Moat/Pretty/Doc/Markdown.hs
+++ b/src/Moat/Pretty/Doc/Markdown.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Moat.Pretty.Doc.Markdown
   ( block,
@@ -48,10 +49,18 @@ markdownBlocks m i = \case
   DocAppend a b -> markdownBlocks m i a ++ markdownBlocks m i b
   DocParagraph d -> [node PARAGRAPH (markdownInlines m i d)]
   DocUnorderedList ds -> [ul (map (markdownListItem m i) ds)]
-  DocOrderedList ds -> [ol (fst (head ds)) (map (markdownListItem m i . snd) ds)]
+  DocOrderedList ds -> [markdownOrderedList m i ds]
   DocCodeBlock d -> [node (CODE_BLOCK T.empty (T.pack (markupText d))) []]
   DocHeader (Header l t) -> [node (HEADING l) (markdownInlines m i t)]
   _ -> []
+
+#if MIN_VERSION_haddock_library(1,11,0)
+markdownOrderedList :: (String -> Node) -> (String -> Node) -> [(Int, DocH String String)] -> Node
+markdownOrderedList m i ds = ol (fst (head ds)) (map (markdownListItem m i . snd) ds)
+#else
+markdownOrderedList :: (String -> Node) -> (String -> Node) -> [DocH String String] -> Node
+markdownOrderedList m i ds = ol 1 (map (markdownListItem m i) ds)
+#endif
 
 markdownListItem :: (String -> Node) -> (String -> Node) -> DocH String String -> Node
 markdownListItem m i doc = node ITEM (markdownBlocks m i doc)

--- a/src/Moat/Pretty/Doc/Markdown.hs
+++ b/src/Moat/Pretty/Doc/Markdown.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Moat.Pretty.Doc.Markdown
+  ( block,
+    br,
+    document,
+    inline,
+    inlineContent,
+    li,
+    markdown,
+    node,
+    ol,
+    para,
+    parseDoc,
+    text,
+    ul,
+  )
+where
+
+import CMarkGFM
+import Documentation.Haddock.Markup
+import Documentation.Haddock.Parser
+import Documentation.Haddock.Types
+import qualified Data.Text as T
+
+-- | Parse a Haddock comment.
+--
+-- See 'markdown' to generate Markdown nodes from this value.
+parseDoc :: String -> DocH m String
+parseDoc docstr = toRegular $ _doc $ parseParas Nothing docstr
+
+-- | Translate Haddock documentation into Markdown nodes.
+markdown ::
+  -- | Function to format a module name as a Markdown node.
+  (String -> Node) ->
+  -- | Function to format an identifier as a Markdown node.
+  (String -> Node) ->
+  -- | Incoming Haddock documentation.
+  DocH String String
+  -- | Generated markdown nodes.
+  -> Node
+markdown m i doc = document (markdownBlocks m i doc)
+
+markdownBlocks ::
+  (String -> Node) ->
+  (String -> Node) ->
+  DocH String String ->
+  [Node]
+markdownBlocks m i = \case
+  DocAppend a b -> markdownBlocks m i a ++ markdownBlocks m i b
+  DocParagraph d -> [node PARAGRAPH (markdownInlines m i d)]
+  DocUnorderedList ds -> [ul (map (markdownListItem m i) ds)]
+  DocOrderedList ds -> [ol (fst (head ds)) (map (markdownListItem m i . snd) ds)]
+  DocCodeBlock d -> [node (CODE_BLOCK T.empty (T.pack (markupText d))) []]
+  DocHeader (Header l t) -> [node (HEADING l) (markdownInlines m i t)]
+  _ -> []
+
+markdownListItem :: (String -> Node) -> (String -> Node) -> DocH String String -> Node
+markdownListItem m i doc = node ITEM (markdownBlocks m i doc)
+
+markdownInlines :: (String -> Node) -> (String -> Node) -> DocH String String -> [Node]
+markdownInlines m i = \case
+  DocAppend a b -> markdownInlines m i a ++ markdownInlines m i b
+  DocString s -> [text s]
+  DocIdentifier x -> [i x]
+  DocIdentifierUnchecked x -> [node (CODE (T.pack x)) []]
+  DocModule (ModLink mo l) -> [link m i mo l]
+  DocEmphasis d -> [node EMPH (markdownInlines m i d)]
+  DocBold d -> [node STRONG (markdownInlines m i d)]
+  DocMonospaced d -> [node (CODE (T.pack (markupText d))) []]
+  DocHyperlink (Hyperlink u l) -> [link m i u l]
+  DocPic (Picture u t) -> [node (IMAGE (T.pack u) (maybe T.empty T.pack t)) []]
+  _ -> []
+
+markupText :: DocH String String -> String
+markupText = markup $ plainMarkup id id
+
+-- | Create a Markdown node with a node type and children.
+node :: NodeType -> [Node] -> Node
+node = Node Nothing
+
+-- | Create a Markdown document node.
+document :: [Node] -> Node
+document = node DOCUMENT
+
+-- | Create a Markdown text node.
+text :: String -> Node
+text s = node (TEXT (T.pack (filterNewlines s))) []
+  where
+    filterNewlines = filter (/= '\n')
+
+-- | Create a Markdown linebreak node.
+br :: Node
+br = node LINEBREAK []
+
+-- | Create a Markdown paragraph node.
+para :: [Node] -> Node
+para = node PARAGRAPH
+
+-- | Create a custom inline Markdown node, with prefix and suffix
+-- literal strings and inline or block child nodes.
+block :: String -> String -> [Node] -> Node
+block prefix suffix = node (CUSTOM_BLOCK (T.pack prefix) (T.pack suffix))
+
+-- | Create a custom inline Markdown node, with prefix and suffix
+-- literal strings and inline child nodes.
+inline :: String -> String -> [Node] -> Node
+inline prefix suffix = node (CUSTOM_INLINE (T.pack prefix) (T.pack suffix))
+
+ul :: [Node] -> Node
+ul = node (LIST (ListAttributes {listType = BULLET_LIST, listTight = True, listStart = 1, listDelim = PERIOD_DELIM}))
+
+ol :: Int -> [Node] -> Node
+ol i = node (LIST (ListAttributes {listType = ORDERED_LIST, listTight = True, listStart = i, listDelim = PERIOD_DELIM}))
+
+li :: [Node] -> Node
+li = node ITEM
+
+link :: (String -> Node) -> (String -> Node) -> String -> Maybe (DocH String String) -> Node
+link m i url lbl = node (LINK (T.pack url) T.empty) (maybe [text url] (markdownInlines m i) lbl)
+
+inlineContent :: Node -> [Node]
+inlineContent n@(Node _ typ xs) =
+  if isBlock typ
+  then concatMap inlineContent xs
+  else [n]
+
+isBlock :: NodeType -> Bool
+isBlock DOCUMENT = True
+isBlock BLOCK_QUOTE = True
+isBlock (LIST _) = True
+isBlock ITEM = True
+isBlock (CODE_BLOCK _ _) = True
+isBlock (HTML_BLOCK _) = True
+isBlock (CUSTOM_BLOCK _ _) = True
+isBlock PARAGRAPH = True
+isBlock (HEADING _) = True
+isBlock THEMATIC_BREAK = True
+isBlock FOOTNOTE_DEFINITION = True
+isBlock _ = False

--- a/src/Moat/Pretty/Doc/Markdown.hs
+++ b/src/Moat/Pretty/Doc/Markdown.hs
@@ -36,7 +36,6 @@ markdown ::
   (String -> Node) ->
   -- | Incoming Haddock documentation.
   DocH String String
-  -- | Generated markdown nodes.
   -> Node
 markdown m i doc = document (markdownBlocks m i doc)
 
@@ -125,15 +124,16 @@ inlineContent n@(Node _ typ xs) =
   else [n]
 
 isBlock :: NodeType -> Bool
-isBlock DOCUMENT = True
-isBlock BLOCK_QUOTE = True
-isBlock (LIST _) = True
-isBlock ITEM = True
-isBlock (CODE_BLOCK _ _) = True
-isBlock (HTML_BLOCK _) = True
-isBlock (CUSTOM_BLOCK _ _) = True
-isBlock PARAGRAPH = True
-isBlock (HEADING _) = True
-isBlock THEMATIC_BREAK = True
-isBlock FOOTNOTE_DEFINITION = True
-isBlock _ = False
+isBlock = \case
+  DOCUMENT -> True
+  BLOCK_QUOTE -> True
+  (LIST _) -> True
+  ITEM -> True
+  (CODE_BLOCK _ _) -> True
+  (HTML_BLOCK _) -> True
+  (CUSTOM_BLOCK _ _) -> True
+  PARAGRAPH -> True
+  (HEADING _) -> True
+  THEMATIC_BREAK -> True
+  FOOTNOTE_DEFINITION -> True
+  _ -> False

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -39,7 +39,7 @@ prettySwiftDataWith indent = \case
       ++ newlineNonEmpty enumTags
       ++ "}"
   MoatStruct {..} ->
-    prettyTypeDoc "" structDoc structFields
+    prettyTypeDoc "" structDoc []
       ++ "struct "
       ++ prettyMoatTypeHeader structName structTyVars
       ++ prettyRawValueAndProtocols Nothing structProtocols
@@ -58,7 +58,7 @@ prettySwiftDataWith indent = \case
       ++ " = "
       ++ prettyMoatType aliasTyp
   MoatNewtype {..} ->
-    prettyTypeDoc "" newtypeDoc [newtypeField]
+    prettyTypeDoc "" newtypeDoc []
       ++ "struct "
       ++ prettyMoatTypeHeader newtypeName newtypeTyVars
       ++ prettyRawValueAndProtocols Nothing newtypeProtocols
@@ -244,7 +244,9 @@ prettyStructFields :: String -> [Field] -> String
 prettyStructFields indents = go
   where
     go [] = ""
-    go (Field {..} : fs) = indents ++ "let " ++ fieldName ++ ": " ++ prettyMoatType fieldType ++ "\n" ++ go fs
+    go (Field {..} : fs) =
+      prettyTypeDoc indents fieldDoc []
+        ++ indents ++ "let " ++ fieldName ++ ": " ++ prettyMoatType fieldType ++ "\n" ++ go fs
 
 prettyNewtypeField :: String -> Field -> String -> String
 prettyNewtypeField indents (Field alias _ _) fieldName = indents ++ "let " ++ alias ++ ": " ++ fieldName ++ "Tag" ++ "\n"

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -7,7 +7,9 @@ module Moat.Types
   ( Annotation (..),
     Backend (..),
     EncodingStyle (..),
+    EnumCase (..),
     EnumEncodingStyle (..),
+    Field (..),
     Interface (..),
     KeepOrDiscard (..),
     MoatData (..),
@@ -125,6 +127,8 @@ data MoatData
     MoatStruct
       { -- | The name of the struct
         structName :: String,
+        -- | Haddock documentation for the struct.
+        structDoc :: Maybe String,
         -- | The struct's type variables
         structTyVars :: [String],
         -- | The kotlin interfaces which the struct implements
@@ -133,9 +137,8 @@ data MoatData
         structProtocols :: [Protocol],
         -- | The kotlin annotations on the struct
         structAnnotations :: [Annotation],
-        -- | The fields of the struct. the pair
-        --   is interpreted as (name, type).
-        structFields :: [(String, MoatType)],
+        -- | The fields of the struct.
+        structFields :: [Field],
         -- | Private types of the struct. Typically
         --   populated by setting 'makeBase'.
         --
@@ -150,6 +153,8 @@ data MoatData
     MoatEnum
       { -- | The name of the enum
         enumName :: String,
+        -- | Haddock documentation for the enum.
+        enumDoc :: Maybe String,
         -- | The enum's type variables
         enumTyVars :: [String],
         -- | The interfaces (Kotlin) which the enum implements
@@ -158,9 +163,8 @@ data MoatData
         enumProtocols :: [Protocol],
         -- | The annotations (Kotlin) on the enum
         enumAnnotations :: [Annotation],
-        -- | The cases of the enum. the type can be interpreted as (name,
-        -- [(label, type)]).
-        enumCases :: [(String, [(Maybe String, MoatType)])],
+        -- | The cases of the enum.
+        enumCases :: [EnumCase],
         -- | The rawValue of an enum. See
         --   https://developer.apple.com/documentation/swift/rawrepresentable/1540698-rawvalue
         --
@@ -190,8 +194,10 @@ data MoatData
     --   Swift backend: Becomes an empty enum with a tag.
     MoatNewtype
       { newtypeName :: String,
+        -- | Haddock documentation for the newtype.
+        newtypeDoc :: Maybe String,
         newtypeTyVars :: [String],
-        newtypeField :: (String, MoatType),
+        newtypeField :: Field,
         newtypeInterfaces :: [Interface],
         newtypeProtocols :: [Protocol], -- TODO: remove this?
         newtypeAnnotations :: [Annotation]
@@ -200,12 +206,30 @@ data MoatData
     MoatAlias
       { -- | the name of the type alias
         aliasName :: String,
+        -- | Haddock documentation for the alias.
+        aliasDoc :: Maybe String,
         -- | the type variables of the type alias
         aliasTyVars :: [String],
         -- | the type this represents (RHS)
         aliasTyp :: MoatType
       }
   deriving stock (Eq, Read, Show, Generic)
+
+-- | An enum case.
+data EnumCase = EnumCase
+  { enumCaseName :: String,
+    enumCaseDoc :: Maybe String,
+    enumCaseFields :: [Field]
+  }
+  deriving stock (Eq, Read, Show)
+
+-- | A named field for enum cases and structs.
+data Field = Field
+  { fieldName :: String,
+    fieldType :: MoatType,
+    fieldDoc :: Maybe String
+  }
+  deriving stock (Eq, Read, Show)
 
 data Backend
   = Kotlin

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -321,6 +321,11 @@ data Options = Options
     -- exists elsewhere.  The default is 'True', i.e., to generate the
     -- instance.
     generateToMoatData :: Bool,
+    -- | Whether or not to generate documentation comments. This works by
+    -- translating Haddock documentation annotations to the target language's
+    -- documentation comment syntax. The default  is 'True', i.e. to generate
+    -- documentation comments.
+    generateDocComments :: Bool,
     -- | Kotlin interfaces to add to a type.
     --   The default (@[]@) will add none.
     dataInterfaces :: [Interface],
@@ -533,6 +538,7 @@ defaultOptions =
       constructorLowerFirst = True,
       generateToMoatType = True,
       generateToMoatData = True,
+      generateDocComments = True,
       dataInterfaces = [],
       dataProtocols = [],
       dataAnnotations = [],

--- a/test/BasicDocSpec.hs
+++ b/test/BasicDocSpec.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE CPP #-}
+
+module BasicDocSpec where
+
+import Common
+import Control.Monad (when)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+
+-- | = Heading
+-- == /Second-level heading, italic/
+--
+-- Paragraphs of documentation for the 'Data' type. This line
+-- should wrap according to your preference.
+--
+-- Some additional markup: /emphasis/, __bold__, @monospaced@.
+--
+-- === __Lists__
+--
+-- Unordered
+--
+-- * Unordered item
+-- * Second unordered item
+-- * Third unordered item
+--
+-- Ordered
+--
+-- 1. Ordered item
+-- 2. Second ordrered item
+-- 3. Third ordered item
+--
+-- == Code block
+--
+-- > func fibonacci(_ n: Int) -> Int {
+-- >     guard n != 0, n != 1 else { return n }
+-- >     return fibonacci(n - 1) + fibonacci(n - 2)
+-- > }
+data Data = Data
+  { -- | First field, it's an Int
+    first :: Int,
+    -- | Second field, it's maybe an Int
+    second :: Maybe Int
+  }
+
+mobileGen
+  ''Data
+
+spec :: Spec
+spec =
+  when hasDoc $ do
+    describe "stays golden" $ do
+      let moduleName = "BasicDocSpec"
+      it "swift" $
+        defaultGolden ("swift" <> moduleName) (showSwift @Data)
+      it "kotlin" $
+        defaultGolden ("kotlin" <> moduleName) (showKotlin @Data)

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Common where
 
 import Data.Proxy (Proxy (..))
@@ -8,3 +9,10 @@ showKotlin = prettyKotlinData $ toMoatData (Proxy @a)
 
 showSwift :: forall a. ToMoatData a => String
 showSwift = prettySwiftData $ toMoatData (Proxy @a)
+
+hasDoc :: Bool
+#if MIN_VERSION_template_haskell(2,18,0)
+hasDoc = True
+#else
+hasDoc = False
+#endif

--- a/test/DuplicateRecordFieldSpec.hs
+++ b/test/DuplicateRecordFieldSpec.hs
@@ -1,0 +1,38 @@
+{- HLINT ignore "Avoid restricted extensions" -}
+{-# LANGUAGE DuplicateRecordFields #-}
+module DuplicateRecordFieldSpec where
+
+import Common
+import Control.Monad (when)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+
+-- | Record 0 with duplicate fields
+data Data0 = Data0
+  { field0 :: Int,      -- ^ duplicate field0
+    field1 :: Maybe Int -- ^ not a duplicate
+  }
+
+-- | Record 1 with duplicate fields
+data Data1 = Data1
+  { field0 :: String,      -- ^ duplicate field0
+    field2 :: Maybe String -- ^ not a duplicate
+  }
+
+mobileGen ''Data0
+mobileGen ''Data1
+
+spec :: Spec
+spec =
+  when hasDoc $ do
+    describe "stays golden" $ do
+      let moduleName = "DuplicateRecordFieldSpec"
+      it "swift" $
+        defaultGolden ("swiftRecord0" <> moduleName) (showSwift @Data0)
+      it "swift" $
+        defaultGolden ("swiftRecord1" <> moduleName) (showSwift @Data1)
+      it "kotlin" $
+        defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Data0)
+      it "kotlin" $
+        defaultGolden ("kotlinRecord1" <> moduleName) (showKotlin @Data1)

--- a/test/EnumValueClassDocSpec.hs
+++ b/test/EnumValueClassDocSpec.hs
@@ -1,0 +1,37 @@
+module EnumValueClassDocSpec where
+
+import Common
+import Control.Monad (when)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+-- | Top-level enum documentation.
+data EnumAsValueClass
+  = -- | 'First'
+    First
+  | -- | 'Second'
+    Second
+  | -- | 'Third'
+    Third
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [Parcelable],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable],
+        enumEncodingStyle = ValueClassStyle
+      }
+  )
+  ''EnumAsValueClass
+
+spec :: Spec
+spec =
+  when hasDoc $ do
+    describe "stays golden" $ do
+      let moduleName = "EnumValueClassDocSpec"
+      it "swift" $
+        defaultGolden ("swift" <> moduleName) (showSwift @EnumAsValueClass)
+      it "kotlin" $
+        defaultGolden ("kotlin" <> moduleName) (showKotlin @EnumAsValueClass)

--- a/test/SumOfProductDocSpec.hs
+++ b/test/SumOfProductDocSpec.hs
@@ -1,0 +1,82 @@
+module SumOfProductDocSpec where
+
+import Common
+import Control.Monad (when)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+-- | Documentation for 'Record0'.
+data Record0 = Record0
+  { record0Field0 :: Int,
+    -- ^ The zeroth field of record 0
+    record0Field1 :: Int
+    -- ^ The first field of record 0
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [LinkEnumInterface "Enum"],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      }
+  )
+  ''Record0
+
+-- | Documentation for 'Record1'.
+data Record1 = Record1
+  { -- | The zeroth field of record 1
+    record1Field0 :: Int,
+    -- | The first field of record 1
+    record1Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable],
+        dataInterfaces = [LinkEnumInterface "Enum"],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      }
+  )
+  ''Record1
+
+-- | Top-level documentation describing 'Enum'.
+data Enum
+  = -- | A constructor.
+    DataCons0 Record0
+  | -- | Another constructor.
+    DataCons1 Record1
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable, SerialName],
+        dataInterfaces = [Parcelable],
+        dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable],
+        sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle,
+              sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"],
+              contentsFieldName = "contents"
+            }
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  when hasDoc $ do
+    describe "stays golden" $ do
+      let moduleName = "SumOfProductDocSpec"
+      it "swift" $ do
+        defaultGolden ("swiftRecord0" <> moduleName) (showSwift @Record0)
+      it "swift" $
+        defaultGolden ("swiftRecord1" <> moduleName) (showSwift @Record1)
+      it "swift" $
+        defaultGolden ("swiftEnum" <> moduleName) (showSwift @Enum)
+      it "kotlin" $
+        defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Record0)
+      it "kotlin" $
+        defaultGolden ("kotlinRecord1" <> moduleName) (showKotlin @Record1)
+      it "kotlin" $
+        defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)

--- a/test/TypeVariableSpec.hs
+++ b/test/TypeVariableSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 module TypeVariableSpec where
 
 import Common
@@ -5,6 +6,7 @@ import Moat
 import Test.Hspec
 import Test.Hspec.Golden
 
+{-# HLINT ignore "Use newtype instead of data" #-}
 data Data a = Data { field0 :: a }
 
 mobileGenWith


### PR DESCRIPTION
Read Haddock comments using `getDoc`, which is available in `template-haskell >= 2.18.0` (GHC 9.2).

Render these comments to [DocC (Swift)](https://www.swift.org/documentation/docc/) and [KDoc (Kotlin)](https://kotlinlang.org/docs/kotlin-doc.html). These are both Markdown-based formats, and for our purposes they differ in how they format identifiers and parameter docs.

`cmark-gfm` was chosen for the Markdown AST and renderer. I didn't want to pull in Pandoc, and while `commonmark` is the new hotness, it's really focused on parsing, so its AST is not easy to generate.

Ancillary changes:
- Unify struct, enum case and newtype fields with a `Field` record. It feels cleaner to add a `fieldDoc` value to this, rather than adding another value to these tuples.
- Enum case constructors can also be documented, so rather than complicate the `[(String, [Field])` tuple with an additional value, turn it into a `EnumCase` record.