### PR TITLE
Ignore nix-direnv cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist-newstyle/
 .golden/*/actual
-.envrc
 result
+
+.envrc
+.direnv/


### PR DESCRIPTION
Using https://github.com/nix-community/nix-direnv with `use flake` is much faster but created `.direnv/`. Ignore that.