### PR TITLE
Propogate changes to cabal file to package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,22 +16,22 @@ default-extensions:
   - RecordWildCards
 
 dependencies:
-  - base >= 4.11 && < 4.18
+  - base >= 4.11 && < 4.19
   - bytestring >= 0.10 && < 0.12
   - case-insensitive >= 1.2 && < 1.3
   - cmark-gfm >= 0.2.5 && < 0.3.0
   - containers >= 0.5.9 && < 0.7
   - haddock-library >= 1.10 && < 1.12
-  - mtl >= 2.2 && < 2.3
-  - primitive >= 0.6.4 && < 0.8
-  - template-haskell >= 2.11 && < 2.20
+  - mtl >= 2.2 && < 2.4
+  - primitive >= 0.6.4 && < 0.9
+  - template-haskell >= 2.11 && < 2.21
   - text >= 1.2 && < 2.1
-  - th-abstraction >= 0.3 && < 0.5
+  - th-abstraction >= 0.3 && < 0.6
   - th-compat >= 0.1.0 && < 0.2
   - time >= 1.8 && < 1.13
   - unordered-containers >= 0.2 && < 0.3
   - uuid-types >= 1.0 && < 1.1
-  - vector >= 0.12 && < 0.13
+  - vector >= 0.12 && < 0.14
 
 build-tools:
   - hspec-discover


### PR DESCRIPTION
Otherwise, `make hpack` will generate a new incorrect cabal file.

```
[0] barry@rickman:~/m/moat|update-package-yaml-to-match-cabal✓
➤ make hpack
hpack .
./moat.cabal is up-to-date
```

:tada: 