### PR TITLE
Pattern match error is annoying

### DIFF
--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -1658,7 +1658,10 @@ suffixBase = \case
 giveBase :: Maybe MoatType -> [Protocol] -> MoatData -> MoatData
 giveBase r ps = \case
   s@MoatStruct {} -> s {structPrivateTypes = [giveProtos ps (suffixBase (stripFields s))]}
-  s@MoatEnum {} -> s {enumPrivateTypes = [giveProtos ps (suffixBase (stripFields s)) {enumRawValue = r}]}
+  s@MoatEnum {} ->
+    case giveProtos ps (suffixBase (stripFields s)) of
+      result@MoatEnum {} -> s {enumPrivateTypes = [result {enumRawValue = r}] }
+      _ -> s
   s -> s
 
 -- | Apply 'giveBase' to a 'MoatData'.


### PR DESCRIPTION
We constantly get this warning. It isn't possible for the `MoatType` to change here, so let's just say if it does change we return the original object.

I considered throwing an error here, but I don't think we want to be in `MoatM` or use `error`. This seems like a simple solution.