### PR TITLE
Wait for garnix before running actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,4 +13,12 @@ jobs:
     - uses: cachix/install-nix-action@v19
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          extra-access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          extra-experimental-features = nix-command flakes ca-derivations
+          extra-substituters = https://cache.nixos.org/ https://cache.garnix.io/
+          extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
+          require-sigs = true
+          sandbox = true
+          extra-system-features = nixos-test benchmark big-parallel kvm
     - run: nix-build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,7 @@
 name: "Run nix build"
 on:
+  check_suite:
+    types: [completed]
   push:
     branches:
       - master

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,4 @@ jobs:
           extra-experimental-features = nix-command flakes ca-derivations
           extra-substituters = https://cache.nixos.org/ https://cache.garnix.io/
           extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
-          require-sigs = true
-          sandbox = true
-          extra-system-features = nixos-test benchmark big-parallel kvm
     - run: nix-build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,5 +1,7 @@
 name: CI
 on:
+  check_suite:
+    types: [completed]
   push:
     branches:
       - master

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,5 +1,7 @@
 name: "Nix"
 on:
+  check_suite:
+    types: [completed]
   push:
     branches:
       - master

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -27,8 +27,8 @@ jobs:
         extra_nix_config: |
           extra-access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           extra-experimental-features = nix-command flakes ca-derivations
-          extra-substituters = https://cache.nixos.org/
-          extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          extra-substituters = https://cache.nixos.org/ https://cache.garnix.io/
+          extra-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=
           require-sigs = true
           sandbox = true
           extra-system-features = nixos-test benchmark big-parallel kvm

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ data class User(
     val age: Int,
 ) : Parcelable
 ```
+
+## Development
+
+We use [garnix][garnix] to cache development shells. You can get directions for
+pulling from that cache via [garnix-cache][their docs].
+
 ## FAQ
 
 ### Why Template Haskell
@@ -109,3 +115,6 @@ $(stringE . show =<< reifyDatatype ''A)
 
 `''A` takes a type constructor `A` and converts it to a `Name`.  We then bind
 from the `Q` monad to generate a string expression via `stringE` and `show` it
+
+[garnix]: https://garnix.io
+[garnix-cache]: https://garnix.io/docs/caching


### PR DESCRIPTION
Wait for garnix to finish building caches before running CI actions. Include the garnix caches in those actions so we don't rebuild a bunch of stuff over and over again.