### PR TITLE
Fix Garnix caching docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ data class User(
 ## Development
 
 We use [garnix][garnix] to cache development shells. You can get directions for
-pulling from that cache via [garnix-cache][their docs].
+pulling from that cache via [their docs][garnix-cache].
 
 ## FAQ
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/354741/235262673-c09f8a9e-1a31-4789-a712-316affdc3f28.png)

After:
![image](https://user-images.githubusercontent.com/354741/235262709-81980d18-e741-4cb3-975d-13c3e88890e4.png)