### PR TITLE
Fix `lift` compilation errors

### DIFF
--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -94,6 +94,7 @@ where
 
 import Control.Monad
 import Control.Monad.Except
+import Control.Monad.Trans
 import Data.Bool (bool)
 import qualified Data.Char as Char
 import Data.Foldable (foldl', foldlM, foldr')

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -94,7 +94,9 @@ where
 
 import Control.Monad
 import Control.Monad.Except
+#if MIN_VERSION_mtl(2,3,0)
 import Control.Monad.Trans
+#endif
 import Data.Bool (bool)
 import qualified Data.Char as Char
 import Data.Foldable (foldl', foldlM, foldr')


### PR DESCRIPTION
`import Control.Monad.Trans` was accidentally(?) removed in the recent formatting commit: https://github.com/MercuryTechnologies/moat/commit/06c1309e3c5a734e37ab5594754d35dbc3ff8873