### PR TITLE
Use var instead of let for swift struct fields

### DIFF
--- a/.golden/swiftAdvancedRecordSpec/golden
+++ b/.golden/swiftAdvancedRecordSpec/golden
@@ -1,4 +1,4 @@
 struct Data: CaseIterable, Hashable, Codable {
-    let field0: Int
-    let field1: Int?
+    var field0: Int
+    var field1: Int?
 }

--- a/.golden/swiftBasicDocSpec/golden
+++ b/.golden/swiftBasicDocSpec/golden
@@ -29,7 +29,7 @@
 ///     }
 struct Data {
     /// First field, it's an Int
-    let first: Int
+    var first: Int
     /// Second field, it's maybe an Int
-    let second: Int?
+    var second: Int?
 }

--- a/.golden/swiftBasicRecordSpec/golden
+++ b/.golden/swiftBasicRecordSpec/golden
@@ -1,4 +1,4 @@
 struct Data {
-    let field0: Int
-    let field1: Int?
+    var field0: Int
+    var field1: Int?
 }

--- a/.golden/swiftMultipleTypeVariableSpec/golden
+++ b/.golden/swiftMultipleTypeVariableSpec/golden
@@ -1,4 +1,4 @@
 struct Data<A, B>: CaseIterable, Hashable, Codable {
-    let field0: A
-    let field1: B
+    var field0: A
+    var field1: B
 }

--- a/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
@@ -1,6 +1,6 @@
 /// Record 0 with duplicate fields
 struct Data0 {
-    let field0: Int
+    var field0: Int
     /// not a duplicate
-    let field1: Int?
+    var field1: Int?
 }

--- a/.golden/swiftRecord0SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord0SumOfProductDocSpec/golden
@@ -1,7 +1,7 @@
 /// Documentation for ``Record0``.
 struct Record0: CaseIterable, Hashable, Codable {
     /// The zeroth field of record 0
-    let record0Field0: Int
+    var record0Field0: Int
     /// The first field of record 0
-    let record0Field1: Int
+    var record0Field1: Int
 }

--- a/.golden/swiftRecord0SumOfProductWithLinkEnumInterfaceSpec/golden
+++ b/.golden/swiftRecord0SumOfProductWithLinkEnumInterfaceSpec/golden
@@ -1,4 +1,4 @@
 struct Record0: CaseIterable, Hashable, Codable {
-    let record0Field0: Int
-    let record0Field1: Int
+    var record0Field0: Int
+    var record0Field1: Int
 }

--- a/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
@@ -1,6 +1,6 @@
 /// Record 1 with duplicate fields
 struct Data1 {
-    let field0: String
+    var field0: String
     /// not a duplicate
-    let field2: String?
+    var field2: String?
 }

--- a/.golden/swiftRecord1SumOfProductDocSpec/golden
+++ b/.golden/swiftRecord1SumOfProductDocSpec/golden
@@ -1,7 +1,7 @@
 /// Documentation for ``Record1``.
 struct Record1: CaseIterable, Hashable, Codable {
     /// The zeroth field of record 1
-    let record1Field0: Int
+    var record1Field0: Int
     /// The first field of record 1
-    let record1Field1: Int
+    var record1Field1: Int
 }

--- a/.golden/swiftRecord1SumOfProductWithLinkEnumInterfaceSpec/golden
+++ b/.golden/swiftRecord1SumOfProductWithLinkEnumInterfaceSpec/golden
@@ -1,4 +1,4 @@
 struct Record1: CaseIterable, Hashable, Codable {
-    let record1Field0: Int
-    let record1Field1: Int
+    var record1Field0: Int
+    var record1Field1: Int
 }

--- a/.golden/swiftStrictFieldsCheck-RecordA/golden
+++ b/.golden/swiftStrictFieldsCheck-RecordA/golden
@@ -1,3 +1,3 @@
 struct RecordA {
-    let fieldA: String
+    var fieldA: String
 }

--- a/.golden/swiftStrictFieldsCheck-RecordB/golden
+++ b/.golden/swiftStrictFieldsCheck-RecordB/golden
@@ -1,3 +1,3 @@
 struct RecordB {
-    let c: String
+    var c: String
 }

--- a/.golden/swiftTypeVariableSpec/golden
+++ b/.golden/swiftTypeVariableSpec/golden
@@ -1,3 +1,3 @@
 struct Data<A>: CaseIterable, Hashable, Codable {
-    let field0: A
+    var field0: A
 }

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -247,7 +247,7 @@ prettyStructFields indents = go
     go (Field {..} : fs) =
       prettyTypeDoc indents fieldDoc []
         ++ indents
-        ++ "let "
+        ++ "var "
         ++ fieldName
         ++ ": "
         ++ prettyMoatType fieldType


### PR DESCRIPTION
At the request of @sebastienwindal. I believe this is the correct syntax for swift (He currently _manually_ edits these for our ios build. I don't believe the swift docs make any references to let for structs

https://docs.swift.org/swift-book/documentation/the-swift-programming-language/classesandstructures/

![image](https://github.com/MercuryTechnologies/moat/assets/13813526/069f5bfc-619e-4ef6-ab7e-ec09db8f7f1e)
