### PR TITLE
Add tag field name for custom codable instances generation

### DIFF
--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -320,7 +320,9 @@ prettyEnum doc anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..
             ++ prettyAnnotations
               Nothing
               noIndent
-              (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
+              ( dontAddParcelizeToSealedClasses
+                  (tagToSumAnnotation tagFieldName : sumAnnotations ++ anns)
+              )
             ++ "sealed class "
             ++ classTyp
             ++ prettyInterfaces ifaces
@@ -346,6 +348,9 @@ prettyEnum doc anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..
     ensureJvmInlineForValueClasses as
       | JvmInline `elem` as = as
       | otherwise = as ++ [JvmInline]
+
+    tagToSumAnnotation :: String -> Annotation
+    tagToSumAnnotation tag = RawAnnotation $ "JsonClassDiscriminator(\"" ++ tag ++ "\")"
 
 newlineNonEmpty :: [a] -> String
 newlineNonEmpty [] = ""

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -476,6 +476,8 @@ data SumOfProductEncodingOptions = SumOfProductEncodingOptions
   -- ^ The field name to use for the products, aeson uses "contents" for the TaggedObject
   -- style. This is unused in the 'TaggedFlatObjectStyle'
   , tagFieldName :: String
+  -- ^ The field name to use for the sum, aeson uses "tag" for the TaggedObject
+  -- style. This is unused in the 'TaggedFlatObjectStyle'
   }
   deriving stock (Eq, Read, Show, Lift)
 

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -475,6 +475,7 @@ data SumOfProductEncodingOptions = SumOfProductEncodingOptions
   , contentsFieldName :: String
   -- ^ The field name to use for the products, aeson uses "contents" for the TaggedObject
   -- style. This is unused in the 'TaggedFlatObjectStyle'
+  , tagFieldName :: String
   }
   deriving stock (Eq, Read, Show, Lift)
 
@@ -501,6 +502,7 @@ defaultSumOfProductEncodingOptions =
     { encodingStyle = TaggedFlatObjectStyle
     , sumAnnotations = []
     , contentsFieldName = "contents"
+    , tagFieldName = "tag"
     }
 
 -- | Enum encoding style.

--- a/test/SumOfProductDocSpec.hs
+++ b/test/SumOfProductDocSpec.hs
@@ -58,6 +58,7 @@ mobileGenWith
             { encodingStyle = TaggedObjectStyle
             , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
             , contentsFieldName = "contents"
+            , tagFieldName = "tag"
             }
       }
   )

--- a/test/SumOfProductDocSpec.hs
+++ b/test/SumOfProductDocSpec.hs
@@ -56,7 +56,7 @@ mobileGenWith
       , sumOfProductEncodingOptions =
           SumOfProductEncodingOptions
             { encodingStyle = TaggedObjectStyle
-            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , sumAnnotations = []
             , contentsFieldName = "contents"
             , tagFieldName = "tag"
             }

--- a/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
@@ -45,6 +45,7 @@ mobileGenWith
             { encodingStyle = TaggedObjectStyle
             , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
             , contentsFieldName = "contents"
+            , tagFieldName = "tag"
             }
       }
   )

--- a/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndNonConcreteCasesSpec.hs
@@ -43,7 +43,7 @@ mobileGenWith
       , sumOfProductEncodingOptions =
           SumOfProductEncodingOptions
             { encodingStyle = TaggedObjectStyle
-            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , sumAnnotations = []
             , contentsFieldName = "contents"
             , tagFieldName = "tag"
             }

--- a/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
@@ -32,6 +32,7 @@ mobileGenWith
             { encodingStyle = TaggedObjectStyle
             , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
             , contentsFieldName = "contents"
+            , tagFieldName = "contents"
             }
       }
   )

--- a/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
+++ b/test/SumOfProductWithTaggedObjectAndSingleNullarySpec.hs
@@ -30,9 +30,9 @@ mobileGenWith
       , sumOfProductEncodingOptions =
           SumOfProductEncodingOptions
             { encodingStyle = TaggedObjectStyle
-            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , sumAnnotations = []
             , contentsFieldName = "contents"
-            , tagFieldName = "contents"
+            , tagFieldName = "tag"
             }
       }
   )

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -45,6 +45,7 @@ mobileGenWith
             { encodingStyle = TaggedObjectStyle
             , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
             , contentsFieldName = "contents"
+            , tagFieldName = "tag"
             }
       }
   )

--- a/test/SumOfProductWithTaggedObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedObjectStyleSpec.hs
@@ -43,7 +43,7 @@ mobileGenWith
       , sumOfProductEncodingOptions =
           SumOfProductEncodingOptions
             { encodingStyle = TaggedObjectStyle
-            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , sumAnnotations = []
             , contentsFieldName = "contents"
             , tagFieldName = "tag"
             }


### PR DESCRIPTION
Aeson allows for JSON encodings with both custom "tag" and "contents" field names. We already pass the contents field name through, we should pass the tag along as well. This change would allow for better custom codable instances for IOS which dont need to manually pass in the tag field.

We sort of do this already by passing in a custom sumAnnotation for android `"JsonClassDiscriminator("tag")"` but this allows for more flexibility on the client's end for generating their own code (without having to mess around with parsing the sum annotation for android or removing it for swift and adding a different one).

EDIT: closed in favor of https://github.com/MercuryTechnologies/moat/pull/69 which does not generate the tag field