### PR TITLE
Fix swift optional newtype

### DIFF
--- a/.golden/swiftBasicNewtypeJoinOptionalsSpec/golden
+++ b/.golden/swiftBasicNewtypeJoinOptionalsSpec/golden
@@ -1,4 +1,4 @@
 struct Newtype {
     typealias NewtypeTag = Tagged<Newtype, Int?>
-    let value: NewtypeTag
+    let value: NewtypeTag?
 }

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -78,7 +78,9 @@ prettySwiftDataWith indent = \case
             ++ " = Tagged<"
             ++ newtypeName
             ++ ", "
-            ++ prettyMoatType (fieldType newtypeField)
+            ++ case (fieldType newtypeField) of
+              Optional t -> prettyMoatType t
+              t -> prettyMoatType t
             ++ ">\n"
             ++ prettyNewtypeField indents newtypeField newtypeName
             ++ "}"
@@ -255,7 +257,17 @@ prettyStructFields indents = go
         ++ go fs
 
 prettyNewtypeField :: String -> Field -> String -> String
-prettyNewtypeField indents (Field alias _ _) fieldName = indents ++ "let " ++ alias ++ ": " ++ fieldName ++ "Tag" ++ "\n"
+prettyNewtypeField indents (Field alias fieldType _) fieldName =
+  indents
+    ++ "let "
+    ++ alias
+    ++ ": "
+    ++ fieldName
+    ++ "Tag"
+    ++ case fieldType of
+      Optional _ -> "?"
+      _ -> ""
+    ++ "\n"
 
 prettyPrivateTypes :: String -> [MoatData] -> String
 prettyPrivateTypes indents = go


### PR DESCRIPTION
Generate optional newtypes correctly, so the property itself is optional rather than the content of the `Tagged` type