### PR TITLE
Propagate 'Codable' bounds through MoatData tyvars

### DIFF
--- a/.golden/kotlinGenericNewtypeSpec/golden
+++ b/.golden/kotlinGenericNewtypeSpec/golden
@@ -1,0 +1,3 @@
+@Parcelize
+@Serializable
+value class LTree<A : Parcelable>(val value: List<A>) : Parcelable

--- a/.golden/kotlinGenericStructSpec/golden
+++ b/.golden/kotlinGenericStructSpec/golden
@@ -1,0 +1,4 @@
+data class Tree<A : Parcelable>(
+    val rootLabel: A,
+    val subForest: List<Tree<A>>,
+) : Parcelable

--- a/.golden/swiftGenericNewtypeSpec/golden
+++ b/.golden/swiftGenericNewtypeSpec/golden
@@ -1,0 +1,4 @@
+struct LTree<A: Codable>: CaseIterable, Hashable, Codable {
+    typealias LTreeTag = Tagged<LTree, [A]>
+    let value: LTreeTag
+}

--- a/.golden/swiftGenericNewtypeSpec/golden
+++ b/.golden/swiftGenericNewtypeSpec/golden
@@ -1,4 +1,4 @@
-struct LTree<A: Codable>: CaseIterable, Hashable, Codable {
+struct LTree<A: Hashable & Codable>: Hashable, Codable {
     typealias LTreeTag = Tagged<LTree, [A]>
     let value: LTreeTag
 }

--- a/.golden/swiftGenericStructSpec/golden
+++ b/.golden/swiftGenericStructSpec/golden
@@ -1,0 +1,4 @@
+struct Tree<A: Codable>: Codable {
+    var rootLabel: A
+    var subForest: [Tree<A>]
+}

--- a/.golden/swiftGenericStructSpec/golden
+++ b/.golden/swiftGenericStructSpec/golden
@@ -1,4 +1,4 @@
-struct Tree<A: Codable>: Codable {
+struct Tree<A: Hashable & Codable>: Hashable, Codable {
     var rootLabel: A
     var subForest: [Tree<A>]
 }

--- a/.golden/swiftMultipleTypeVariableSpec/golden
+++ b/.golden/swiftMultipleTypeVariableSpec/golden
@@ -1,4 +1,4 @@
-struct Data<A: Codable, B: Codable>: CaseIterable, Hashable, Codable {
+struct Data<A: Hashable & Codable, B: Hashable & Codable>: CaseIterable, Hashable, Codable {
     var field0: A
     var field1: B
 }

--- a/.golden/swiftMultipleTypeVariableSpec/golden
+++ b/.golden/swiftMultipleTypeVariableSpec/golden
@@ -1,4 +1,4 @@
-struct Data<A, B>: CaseIterable, Hashable, Codable {
+struct Data<A: Codable, B: Codable>: CaseIterable, Hashable, Codable {
     var field0: A
     var field1: B
 }

--- a/.golden/swiftTypeVariableSpec/golden
+++ b/.golden/swiftTypeVariableSpec/golden
@@ -1,3 +1,3 @@
-struct Data<A: Codable>: CaseIterable, Hashable, Codable {
+struct Data<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
     var field0: A
 }

--- a/.golden/swiftTypeVariableSpec/golden
+++ b/.golden/swiftTypeVariableSpec/golden
@@ -1,3 +1,3 @@
-struct Data<A>: CaseIterable, Hashable, Codable {
+struct Data<A: Codable>: CaseIterable, Hashable, Codable {
     var field0: A
 }

--- a/moat.cabal
+++ b/moat.cabal
@@ -83,6 +83,8 @@ test-suite spec
       DuplicateRecordFieldSpec
       EnumValueClassDocSpec
       EnumValueClassSpec
+      GenericNewtypeSpec
+      GenericStructSpec
       MultipleTypeVariableSpec
       StrictEnumsSpec
       StrictFieldsSpec

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -109,17 +109,17 @@ prettyRawValueAndProtocols Nothing ps = ": " ++ prettyProtocols ps
 prettyRawValueAndProtocols (Just ty) [] = ": " ++ prettyMoatType ty
 prettyRawValueAndProtocols (Just ty) ps = ": " ++ prettyMoatType ty ++ ", " ++ prettyProtocols ps
 
+prettyProtocol :: Protocol -> String
+prettyProtocol = \case
+  Hashable -> "Hashable"
+  Codable -> "Codable"
+  Equatable -> "Equatable"
+  OtherProtocol s -> s
+
 prettyProtocols :: [Protocol] -> String
 prettyProtocols = \case
   [] -> ""
   ps -> intercalate ", " (prettyProtocol <$> ps)
-    where
-      prettyProtocol :: Protocol -> String
-      prettyProtocol = \case
-        Hashable -> "Hashable"
-        Codable -> "Codable"
-        Equatable -> "Equatable"
-        OtherProtocol s -> s
 
 -- TODO: Need a plan to avoid @error@ in these pure functions
 {-# ANN prettyTags "HLint: ignore" #-}
@@ -269,7 +269,27 @@ onLast :: (a -> a) -> [a] -> [a]
 onLast _ [] = []
 onLast f (x : xs) = x : map f xs
 
+-- | Copy protocols from the parent type to upper bounds of generic type
+--   parameters.
+--
+--   This is needed for protocols with compiler-synthesized implementations
+--   (similar to 'deriving stock'), of which there are currently three:
+--
+--   - 'Equatable'
+--   - 'Hashable'
+--   - 'Codable'
+--
+--   See the [Swift documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols#Adopting-a-Protocol-Using-a-Synthesized-Implementation).
 addTyVarBounds :: [String] -> [Protocol] -> [String]
-addTyVarBounds tyVars protos
-  | Codable `elem` protos = map (++ ": Codable") tyVars
-  | otherwise = tyVars
+addTyVarBounds tyVars protos =
+  let isSynthesized :: Protocol -> Bool
+      isSynthesized = \case
+        Hashable -> True
+        Codable -> True
+        Equatable -> True
+        OtherProtocol _ -> False
+      synthesizedProtos = filter isSynthesized protos
+      bounds = ": " ++ intercalate " & " (map prettyProtocol synthesizedProtos)
+   in case synthesizedProtos of
+        [] -> tyVars
+        _ -> map (++ bounds) tyVars

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -28,7 +28,7 @@ prettySwiftDataWith indent = \case
   MoatEnum {..} ->
     prettyTypeDoc "" enumDoc []
       ++ "enum "
-      ++ prettyMoatTypeHeader enumName enumTyVars
+      ++ prettyMoatTypeHeader enumName (addTyVarBounds enumTyVars enumProtocols)
       ++ prettyRawValueAndProtocols enumRawValue enumProtocols
       ++ " {"
       ++ newlineNonEmpty enumCases
@@ -41,7 +41,7 @@ prettySwiftDataWith indent = \case
   MoatStruct {..} ->
     prettyTypeDoc "" structDoc []
       ++ "struct "
-      ++ prettyMoatTypeHeader structName structTyVars
+      ++ prettyMoatTypeHeader structName (addTyVarBounds structTyVars structProtocols)
       ++ prettyRawValueAndProtocols Nothing structProtocols
       ++ " {"
       ++ newlineNonEmpty structFields
@@ -54,13 +54,13 @@ prettySwiftDataWith indent = \case
   MoatAlias {..} ->
     prettyTypeDoc "" aliasDoc []
       ++ "typealias "
-      ++ prettyMoatTypeHeader aliasName aliasTyVars
+      ++ prettyMoatTypeHeader aliasName (addTyVarBounds aliasTyVars [])
       ++ " = "
       ++ prettyMoatType aliasTyp
   MoatNewtype {..} ->
     prettyTypeDoc "" newtypeDoc []
       ++ "struct "
-      ++ prettyMoatTypeHeader newtypeName newtypeTyVars
+      ++ prettyMoatTypeHeader newtypeName (addTyVarBounds newtypeTyVars newtypeProtocols)
       ++ prettyRawValueAndProtocols Nothing newtypeProtocols
       ++ " {\n"
       ++ indents
@@ -268,3 +268,8 @@ prettyPrivateTypes indents = go
 onLast :: (a -> a) -> [a] -> [a]
 onLast _ [] = []
 onLast f (x : xs) = x : map f xs
+
+addTyVarBounds :: [String] -> [Protocol] -> [String]
+addTyVarBounds tyVars protos
+  | Codable `elem` protos = map (++ ": Codable") tyVars
+  | otherwise = tyVars

--- a/test/GenericNewtypeSpec.hs
+++ b/test/GenericNewtypeSpec.hs
@@ -16,7 +16,7 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable]
       , dataInterfaces = [Parcelable]
-      , dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      , dataProtocols = [Hashable, Codable]
       , dataRawValue = Just Str
       , generateDocComments = False
       }

--- a/test/GenericNewtypeSpec.hs
+++ b/test/GenericNewtypeSpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module GenericNewtypeSpec where
+
+import Common
+import Data.List.NonEmpty (NonEmpty)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude
+
+newtype LTree a = LTree (NonEmpty a)
+  deriving stock (Show, Eq)
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable]
+      , dataInterfaces = [Parcelable]
+      , dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      , dataRawValue = Just Str
+      , generateDocComments = False
+      }
+  )
+  ''LTree
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "GenericNewtypeSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @(LTree _))
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @(LTree _))

--- a/test/GenericStructSpec.hs
+++ b/test/GenericStructSpec.hs
@@ -12,7 +12,7 @@ import Prelude
 mobileGenWith
   ( defaultOptions
       { dataInterfaces = [Parcelable]
-      , dataProtocols = [Codable]
+      , dataProtocols = [Hashable, Codable]
       , generateDocComments = False
       }
   )

--- a/test/GenericStructSpec.hs
+++ b/test/GenericStructSpec.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module GenericStructSpec where
+
+import Common
+import Data.Tree (Tree)
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude
+
+mobileGenWith
+  ( defaultOptions
+      { dataInterfaces = [Parcelable]
+      , dataProtocols = [Codable]
+      , generateDocComments = False
+      }
+  )
+  ''Tree
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "GenericStructSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @(Tree _))
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @(Tree _))


### PR DESCRIPTION
Fixes #73 

Similar to the work done in #50, propagate the `Codable` upper bound through MoatData type variables in generated Swift; this is required to support generic data types with `Codable`.