### PR TITLE
Fix codegen for sum-of-products with generic parameters

### DIFF
--- a/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
@@ -1,0 +1,11 @@
+@JsonClassDiscriminator("direction")
+@Serializable
+sealed class CursorInput<A> {
+    @Serializable
+    @SerialName("nextPage")
+    data class NextPage(val key: A?) : CursorInput()
+
+    @Serializable
+    @SerialName("previousPage")
+    data class PreviousPage(val key: A) : CursorInput()
+}

--- a/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
@@ -3,9 +3,9 @@
 sealed class CursorInput<A> {
     @Serializable
     @SerialName("nextPage")
-    data class NextPage(val key: A?) : CursorInput()
+    data class NextPage<A>(val key: A?) : CursorInput<A>()
 
     @Serializable
     @SerialName("previousPage")
-    data class PreviousPage(val key: A) : CursorInput()
+    data class PreviousPage<A>(val key: A) : CursorInput<A>()
 }

--- a/.golden/swiftSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/swiftSumOfProductWithTypeParameterSpec/golden
@@ -1,0 +1,4 @@
+enum CursorInput<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
+    case nextPage(A?)
+    case previousPage(A)
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -94,6 +94,7 @@ test-suite spec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec
       SumOfProductWithTaggedObjectAndSingleNullarySpec
       SumOfProductWithTaggedObjectStyleSpec
+      SumOfProductWithTypeParameterSpec
       TypeVariableSpec
       Moat
       Moat.Class

--- a/test/SumOfProductWithTypeParameterSpec.hs
+++ b/test/SumOfProductWithTypeParameterSpec.hs
@@ -1,0 +1,38 @@
+module SumOfProductWithTypeParameterSpec where
+
+import Common
+import Data.List (stripPrefix)
+import Data.Maybe
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data CursorInput a
+  = CursorInputNextPage (Maybe a)
+  | CursorInputPreviousPage a
+
+mobileGenWith
+  ( defaultOptions
+      { constructorModifier = \body -> fromMaybe body (stripPrefix "CursorInput" body)
+      , dataAnnotations = [Serializable, SerialName]
+      , dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      , sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle
+            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"direction\")"]
+            , contentsFieldName = "key"
+            , tagFieldName = "direction"
+            }
+      }
+  )
+  ''CursorInput
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithTypeParameterSpec"
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @(CursorInput _))
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @(CursorInput _))


### PR DESCRIPTION
`prettyKotlin` didn't take generics into account when using TaggedObjectStyle.