### PR TITLE
swift: add Codable implementation for sum-of-product types

### DIFF
--- a/.golden/kotlinEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,0 +1,2 @@
+@Serializable
+sealed class Enum : Parcelable

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -10,4 +10,9 @@ sealed class Enum : Parcelable {
     @Serializable
     @SerialName("dataCons1")
     data class DataCons1(val contents: Record1) : Enum()
+
+    @Parcelize
+    @Serializable
+    @SerialName("dataCons2")
+    data object DataCons2 : Enum()
 }

--- a/.golden/kotlinRecord0SumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/kotlinRecord0SumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record0(
+    val record0Field0: Int,
+    val record0Field1: Int,
+) : Parcelable

--- a/.golden/kotlinRecord1SumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/kotlinRecord1SumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,0 +1,6 @@
+@Parcelize
+@Serializable
+data class Record1(
+    val record1Field0: Int,
+    val record1Field1: Int,
+) : Parcelable

--- a/.golden/swiftEnumSumOfProductDocSpec/golden
+++ b/.golden/swiftEnumSumOfProductDocSpec/golden
@@ -4,4 +4,37 @@ enum Enum: CaseIterable, Hashable, Codable {
     case dataCons0(Record0)
     /// Another constructor.
     case dataCons1(Record1)
+
+    enum CodingKeys: String, CodingKey {
+        case tag
+        case contents
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .tag)
+        switch discriminator {
+            case "dataCons0":
+                self = .dataCons0(try container.decode(Record0.self, forKey: .contents))
+            case "dataCons1":
+                self = .dataCons1(try container.decode(Record1.self, forKey: .contents))
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Enum.\(discriminator)")
+                )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case let .dataCons0(contents):
+                try container.encode("dataCons0", forKey: .tag)
+                try container.encode(contents, forKey: .contents)
+            case let .dataCons1(contents):
+                try container.encode("dataCons1", forKey: .tag)
+                try container.encode(contents, forKey: .contents)
+        }
+    }
 }

--- a/.golden/swiftEnumSumOfProductSpec/golden
+++ b/.golden/swiftEnumSumOfProductSpec/golden
@@ -1,4 +1,48 @@
-enum Enum: CaseIterable, Hashable, Codable {
+enum Enum: Hashable, Codable {
     case dataCons0(_ enumField0: Int, _ enumField1: Int)
     case dataCons1(_ enumField2: String, _ enumField3: String)
+
+    enum CodingKeys: String, CodingKey {
+        case tag
+        case enumField0
+        case enumField1
+        case enumField2
+        case enumField3
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .tag)
+        switch discriminator {
+            case "dataCons0":
+                self = .dataCons0(
+                    try container.decode(Int.self, forKey: .enumField0),
+                    try container.decode(Int.self, forKey: .enumField1)
+                )
+            case "dataCons1":
+                self = .dataCons1(
+                    try container.decode(String.self, forKey: .enumField2),
+                    try container.decode(String.self, forKey: .enumField3)
+                )
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Enum.\(discriminator)")
+                )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case let .dataCons0:
+                try container.encode("dataCons0", forKey: .tag)
+                try container.encode(enumField0, forKey: .enumField0)
+                try container.encode(enumField1, forKey: .enumField1)
+            case let .dataCons1:
+                try container.encode("dataCons1", forKey: .tag)
+                try container.encode(enumField2, forKey: .enumField2)
+                try container.encode(enumField3, forKey: .enumField3)
+        }
+    }
 }

--- a/.golden/swiftEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/swiftEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,6 +1,8 @@
-enum Enum: CaseIterable, Hashable, Codable {
+enum Enum: Codable {
     case dataCons0(Record0)
     case dataCons1(Record1)
+    case dataCons2
+    case _unknown
 
     enum CodingKeys: String, CodingKey {
         case tag
@@ -14,11 +16,10 @@ enum Enum: CaseIterable, Hashable, Codable {
                 self = .dataCons0(try Record0.init(from: decoder))
             case "dataCons1":
                 self = .dataCons1(try Record1.init(from: decoder))
+            case "dataCons2":
+                self = .dataCons2
             default:
-                throw DecodingError.typeMismatch(
-                    CodingKeys.self,
-                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Enum.\(discriminator)")
-                )
+                self = ._unknown
         }
     }
 
@@ -31,6 +32,13 @@ enum Enum: CaseIterable, Hashable, Codable {
             case let .dataCons1(value):
                 try container.encode("dataCons1", forKey: .tag)
                 try value.encode(to: encoder)
+            case .dataCons2:
+                try container.encode("dataCons2", forKey: .tag)
+            case ._unknown:
+                throw EncodingError.invalidValue(
+                    self,
+                    .init(codingPath: encoder.codingPath, debugDescription: "Can't encode value: Enum._unknown")
+                )
         }
     }
 }

--- a/.golden/swiftEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/swiftEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,9 +1,11 @@
-enum Enum: CaseIterable, Hashable, Codable {
+enum Enum: Codable {
     case dataCons0(Record0)
     case dataCons1(Record1)
+    case dataCons2
 
     enum CodingKeys: String, CodingKey {
         case tag
+        case contents
     }
 
     init(from decoder: any Decoder) throws {
@@ -11,9 +13,11 @@ enum Enum: CaseIterable, Hashable, Codable {
         let discriminator = try container.decode(String.self, forKey: .tag)
         switch discriminator {
             case "dataCons0":
-                self = .dataCons0(try Record0.init(from: decoder))
+                self = .dataCons0(try container.decode(Record0.self, forKey: .contents))
             case "dataCons1":
-                self = .dataCons1(try Record1.init(from: decoder))
+                self = .dataCons1(try container.decode(Record1.self, forKey: .contents))
+            case "dataCons2":
+                self = .dataCons2
             default:
                 throw DecodingError.typeMismatch(
                     CodingKeys.self,
@@ -25,12 +29,14 @@ enum Enum: CaseIterable, Hashable, Codable {
     func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch (self) {
-            case let .dataCons0(value):
+            case let .dataCons0(contents):
                 try container.encode("dataCons0", forKey: .tag)
-                try value.encode(to: encoder)
-            case let .dataCons1(value):
+                try container.encode(contents, forKey: .contents)
+            case let .dataCons1(contents):
                 try container.encode("dataCons1", forKey: .tag)
-                try value.encode(to: encoder)
+                try container.encode(contents, forKey: .contents)
+            case .dataCons2:
+                try container.encode("dataCons2", forKey: .tag)
         }
     }
 }

--- a/.golden/swiftRecord0SumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/swiftRecord0SumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,0 +1,4 @@
+struct Record0: Codable {
+    var record0Field0: Int
+    var record0Field1: Int
+}

--- a/.golden/swiftRecord0SumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/swiftRecord0SumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,0 +1,4 @@
+struct Record0: Codable {
+    var record0Field0: Int
+    var record0Field1: Int
+}

--- a/.golden/swiftRecord1SumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/swiftRecord1SumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,0 +1,4 @@
+struct Record1: Codable {
+    var record1Field0: Int
+    var record1Field1: Int
+}

--- a/.golden/swiftRecord1SumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/swiftRecord1SumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,0 +1,4 @@
+struct Record1: Codable {
+    var record1Field0: Int
+    var record1Field1: Int
+}

--- a/.golden/swiftSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/swiftSumOfProductWithTypeParameterSpec/golden
@@ -1,4 +1,37 @@
 enum CursorInput<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
     case nextPage(A?)
     case previousPage(A)
+
+    enum CodingKeys: String, CodingKey {
+        case direction
+        case key
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .direction)
+        switch discriminator {
+            case "nextPage":
+                self = .nextPage(try container.decode(A?.self, forKey: .key))
+            case "previousPage":
+                self = .previousPage(try container.decode(A.self, forKey: .key))
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown direction: CursorInput.\(discriminator)")
+                )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case let .nextPage(key):
+                try container.encode("nextPage", forKey: .direction)
+                try container.encode(key, forKey: .key)
+            case let .previousPage(key):
+                try container.encode("previousPage", forKey: .direction)
+                try container.encode(key, forKey: .key)
+        }
+    }
 }

--- a/moat.cabal
+++ b/moat.cabal
@@ -91,6 +91,7 @@ test-suite spec
       SumOfProductDocSpec
       SumOfProductSpec
       SumOfProductWithLinkEnumInterfaceSpec
+      SumOfProductWithTaggedFlatObjectStyleSpec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec
       SumOfProductWithTaggedObjectAndSingleNullarySpec
       SumOfProductWithTaggedObjectStyleSpec

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -188,6 +188,12 @@ data MoatData
       --   Only used by the Swift backend.
       , enumSumOfProductEncodingOption :: SumOfProductEncodingOptions
       , enumEnumEncodingStyle :: EnumEncodingStyle
+      , enumEnumUnknownCase :: Maybe String
+      -- ^ Add an enum case to represent values added to this enum in the future.
+      --
+      --   Only used by the Swift backend. Generated 'decode' functions for
+      --   sum-of-product types will fall back to this case, but clients
+      --   have to implement fallback logic for simple enums.
       }
   | -- | A newtype.
     --   Kotlin backend: becomes a value class.
@@ -460,6 +466,10 @@ data Options = Options
   --   'EnumEncodingStyle'.
   --
   --   This option is only meaningful on the Kotlin backend.
+  , enumUnknownCase :: Maybe String
+  -- ^ Add an enum case to represent values added to this enum in the future.
+  --
+  --   On the Kotlin backend, this is ignored when using [ValueClassStyle].
   }
 
 data SumOfProductEncodingOptions = SumOfProductEncodingOptions
@@ -477,7 +487,7 @@ data SumOfProductEncodingOptions = SumOfProductEncodingOptions
   -- style. This is unused in the 'TaggedFlatObjectStyle'
   , tagFieldName :: String
   -- ^ The field name to use for the sum, aeson uses "tag" for the TaggedObject
-  -- style. This is unused in the 'TaggedFlatObjectStyle'
+  -- style.
   }
   deriving stock (Eq, Read, Show, Lift)
 
@@ -545,6 +555,7 @@ data EnumEncodingStyle = EnumClassStyle | ValueClassStyle
 --   , optionalExpand = False
 --   , sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
 --   , enumEncodingStyle = EnumClassStyle
+--   , enumUnknownCase = Nothing
 --   }
 -- @
 defaultOptions :: Options
@@ -574,6 +585,7 @@ defaultOptions =
     , optionalExpand = False
     , sumOfProductEncodingOptions = defaultSumOfProductEncodingOptions
     , enumEncodingStyle = EnumClassStyle
+    , enumUnknownCase = Nothing
     }
 
 data KeepOrDiscard = Keep | Discard

--- a/test/SumOfProductSpec.hs
+++ b/test/SumOfProductSpec.hs
@@ -15,7 +15,7 @@ mobileGenWith
   ( defaultOptions
       { dataAnnotations = [Parcelize, Serializable]
       , dataInterfaces = [Parcelable]
-      , dataProtocols = [OtherProtocol "CaseIterable", Hashable, Codable]
+      , dataProtocols = [Hashable, Codable]
       }
   )
   ''Enum

--- a/test/SumOfProductWithTaggedFlatObjectStyleSpec.hs
+++ b/test/SumOfProductWithTaggedFlatObjectStyleSpec.hs
@@ -1,4 +1,4 @@
-module SumOfProductWithTaggedObjectStyleSpec where
+module SumOfProductWithTaggedFlatObjectStyleSpec where
 
 import Common
 import Moat
@@ -46,11 +46,12 @@ mobileGenWith
       , dataProtocols = [Codable]
       , sumOfProductEncodingOptions =
           SumOfProductEncodingOptions
-            { encodingStyle = TaggedObjectStyle
+            { encodingStyle = TaggedFlatObjectStyle
             , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
-            , contentsFieldName = "contents"
             , tagFieldName = "tag"
+            , contentsFieldName = "contents"
             }
+      , enumUnknownCase = Just "_unknown"
       }
   )
   ''Enum
@@ -58,7 +59,7 @@ mobileGenWith
 spec :: Spec
 spec =
   describe "stays golden" $ do
-    let moduleName = "SumOfProductWithTaggedObjectStyleSpec"
+    let moduleName = "SumOfProductWithTaggedFlatObjectStyleSpec"
     it "kotlin" $
       defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Record0)
     it "kotlin" $


### PR DESCRIPTION
Support sum-of-product types in Swift by generating Codable implementations.

There are a couple of dimensions here, so I attempted to cover them all in tests:

- encoding style: TaggedObjectStyle, TaggedFlatObjectStyle
- case constructor: no fields, single unnamed field (linked record type), multiple named fields (only seen in TaggedFlatObjectStyle with record constructors)

In order to support "unknown" cases instead of throwing an error, the decoding logic needs to know the "unknown" field name at codegen time, so we are strongly nudged into making "unknown enum cases" a supported feature. This is done by adding `enumUnknownCase :: Maybe String` to `Options` and a corresponding `enumEnumUnknownCase` to `MoatEnum`. Only sum-of-product decoding takes this into account when decoding; the unknown case is generated for all enums as it doesn't hurt anything, but clients will have to implement their own Codable extensions to fall back to the unknown case for bare ("C-style") enums. We could implement that if desired, but I left that for a future improvement.

