### PR TITLE
Kotlin: Fix syntax for unary constructor when parent has type parameters

### DIFF
--- a/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
@@ -11,5 +11,5 @@ sealed class CursorInput<A> {
 
     @Serializable
     @SerialName("unknown")
-    data object Unknown<A> : CursorInput<A>()
+    data object Unknown : CursorInput<Nothing>()
 }

--- a/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
@@ -8,4 +8,8 @@ sealed class CursorInput<A> {
     @Serializable
     @SerialName("previousPage")
     data class PreviousPage<A>(val key: A) : CursorInput<A>()
+
+    @Serializable
+    @SerialName("unknown")
+    data object Unknown<A> : CursorInput<A>()
 }

--- a/.golden/swiftSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/swiftSumOfProductWithTypeParameterSpec/golden
@@ -1,6 +1,7 @@
 enum CursorInput<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
     case nextPage(A?)
     case previousPage(A)
+    case unknown
 
     enum CodingKeys: String, CodingKey {
         case direction
@@ -15,6 +16,8 @@ enum CursorInput<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
                 self = .nextPage(try container.decode(A?.self, forKey: .key))
             case "previousPage":
                 self = .previousPage(try container.decode(A.self, forKey: .key))
+            case "unknown":
+                self = .unknown
             default:
                 throw DecodingError.typeMismatch(
                     CodingKeys.self,
@@ -32,6 +35,8 @@ enum CursorInput<A: Hashable & Codable>: CaseIterable, Hashable, Codable {
             case let .previousPage(key):
                 try container.encode("previousPage", forKey: .direction)
                 try container.encode(key, forKey: .key)
+            case .unknown:
+                try container.encode("unknown", forKey: .direction)
         }
     }
 }

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -253,9 +253,9 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
             ++ prettyAnnotations (Just caseNm) indents anns
             ++ indents
             ++ "data object "
-            ++ caseTypeHeader caseNm
+            ++ objectCaseTypeHeader caseNm
             ++ " : "
-            ++ parentTypeHeader
+            ++ objectParentTypeHeader
             ++ "()"
         EnumCase caseNm _ _ ->
           error $
@@ -269,6 +269,12 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
 
     parentTypeHeader :: String
     parentTypeHeader = prettyMoatTypeHeader parentName tyVars
+
+    objectCaseTypeHeader :: String -> String
+    objectCaseTypeHeader name = prettyMoatTypeHeader (toUpperFirst name) []
+
+    objectParentTypeHeader :: String
+    objectParentTypeHeader = prettyMoatTypeHeader parentName (replicate (length tyVars) "Nothing")
 
 prettyEnum ::
   () =>

--- a/test/SumOfProductWithTypeParameterSpec.hs
+++ b/test/SumOfProductWithTypeParameterSpec.hs
@@ -11,6 +11,7 @@ import Prelude hiding (Enum)
 data CursorInput a
   = CursorInputNextPage (Maybe a)
   | CursorInputPreviousPage a
+  | CursorInputUnknown
 
 mobileGenWith
   ( defaultOptions


### PR DESCRIPTION
For the Haskell type

```haskell
data CursorInput a
  = CursorInputNextPage (Maybe a)
  | CursorInputPreviousPage a
  | CursorInputUnknown
```

we're generating:

```kotlin
@JsonClassDiscriminator("direction")
@Serializable
sealed class CursorInput<A> {
    @Serializable
    @SerialName("nextPage")
    data class NextPage<A>(val key: A?) : CursorInput<A>()

    @Serializable
    @SerialName("previousPage")
    data class PreviousPage<A>(val key: A) : CursorInput<A>()

    @Serializable
    @SerialName("unknown")
    data object Unknown<A> : CursorInput<A>()
}
```

when it should be:

```kotlin
@JsonClassDiscriminator("direction")
@Serializable
sealed class CursorInput<A> {
    @Serializable
    @SerialName("nextPage")
    data class NextPage<A>(val key: A?) : CursorInput<A>()

    @Serializable
    @SerialName("previousPage")
    data class PreviousPage<A>(val key: A) : CursorInput<A>()

    @Serializable
    @SerialName("unknown")
    data object Unknown : CursorInput<Nothing>()
}
```