### PR TITLE
Kotlin: Generate sealed interfaces for tagged objects

### DIFF
--- a/.golden/kotlinEnumSumOfProductDocSpec/golden
+++ b/.golden/kotlinEnumSumOfProductDocSpec/golden
@@ -1,16 +1,16 @@
 /** Top-level documentation describing [Enum]. */
 @JsonClassDiscriminator("tag")
 @Serializable
-sealed class Enum : Parcelable {
+sealed interface Enum : Parcelable {
     /** A constructor. */
     @Parcelize
     @Serializable
     @SerialName("dataCons0")
-    data class DataCons0(val contents: Record0) : Enum()
+    data class DataCons0(val contents: Record0) : Enum
 
     /** Another constructor. */
     @Parcelize
     @Serializable
     @SerialName("dataCons1")
-    data class DataCons1(val contents: Record1) : Enum()
+    data class DataCons1(val contents: Record1) : Enum
 }

--- a/.golden/kotlinEnumSumOfProductSpec/golden
+++ b/.golden/kotlinEnumSumOfProductSpec/golden
@@ -1,2 +1,2 @@
 @Serializable
-sealed class Enum : Parcelable
+sealed interface Enum : Parcelable

--- a/.golden/kotlinEnumSumOfProductWithLinkEnumInterfaceSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithLinkEnumInterfaceSpec/golden
@@ -1,2 +1,2 @@
 @Serializable(with = Enum1Serializer::class)
-sealed class Enum : Parcelable
+sealed interface Enum : Parcelable

--- a/.golden/kotlinEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedFlatObjectStyleSpec/golden
@@ -1,2 +1,2 @@
 @Serializable
-sealed class Enum : Parcelable
+sealed interface Enum : Parcelable

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectAndNonConcreteCasesSpec/golden
@@ -1,13 +1,13 @@
 @JsonClassDiscriminator("tag")
 @Serializable
-sealed class Enum : Parcelable {
+sealed interface Enum : Parcelable {
     @Parcelize
     @Serializable
     @SerialName("dataCons0")
-    data class DataCons0(val contents: List<Record0>) : Enum()
+    data class DataCons0(val contents: List<Record0>) : Enum
 
     @Parcelize
     @Serializable
     @SerialName("dataCons1")
-    data class DataCons1(val contents: List<Record1>) : Enum()
+    data class DataCons1(val contents: List<Record1>) : Enum
 }

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectAndSingleNullarySpec/golden
@@ -1,13 +1,13 @@
 @JsonClassDiscriminator("tag")
 @Serializable
-sealed class Enum : Parcelable {
+sealed interface Enum : Parcelable {
     @Parcelize
     @Serializable
     @SerialName("dataCons0")
-    data class DataCons0(val contents: Record0) : Enum()
+    data class DataCons0(val contents: Record0) : Enum
 
     @Parcelize
     @Serializable
     @SerialName("dataCons1")
-    data object DataCons1 : Enum()
+    data object DataCons1 : Enum
 }

--- a/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithTaggedObjectStyleSpec/golden
@@ -1,18 +1,18 @@
 @JsonClassDiscriminator("tag")
 @Serializable
-sealed class Enum : Parcelable {
+sealed interface Enum : Parcelable {
     @Parcelize
     @Serializable
     @SerialName("dataCons0")
-    data class DataCons0(val contents: Record0) : Enum()
+    data class DataCons0(val contents: Record0) : Enum
 
     @Parcelize
     @Serializable
     @SerialName("dataCons1")
-    data class DataCons1(val contents: Record1) : Enum()
+    data class DataCons1(val contents: Record1) : Enum
 
     @Parcelize
     @Serializable
     @SerialName("dataCons2")
-    data object DataCons2 : Enum()
+    data object DataCons2 : Enum
 }

--- a/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
+++ b/.golden/kotlinSumOfProductWithTypeParameterSpec/golden
@@ -1,15 +1,15 @@
 @JsonClassDiscriminator("direction")
 @Serializable
-sealed class CursorInput<A> {
+sealed interface CursorInput<A> {
     @Serializable
     @SerialName("nextPage")
-    data class NextPage<A>(val key: A?) : CursorInput<A>()
+    data class NextPage<A>(val key: A?) : CursorInput<A>
 
     @Serializable
     @SerialName("previousPage")
-    data class PreviousPage<A>(val key: A) : CursorInput<A>()
+    data class PreviousPage<A>(val key: A) : CursorInput<A>
 
     @Serializable
     @SerialName("unknown")
-    data object Unknown : CursorInput<Nothing>()
+    data object Unknown : CursorInput<Nothing>
 }

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -247,7 +247,6 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
             ++ prettyMoatType caseTy
             ++ ") : "
             ++ parentTypeHeader
-            ++ "()"
         EnumCase caseNm caseDoc [] ->
           prettyTypeDoc indents caseDoc []
             ++ prettyAnnotations (Just caseNm) indents anns
@@ -256,7 +255,6 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
             ++ objectCaseTypeHeader caseNm
             ++ " : "
             ++ objectParentTypeHeader
-            ++ "()"
         EnumCase caseNm _ _ ->
           error $
             "prettyTaggedObject: The data constructor "
@@ -326,7 +324,7 @@ prettyEnum doc anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..
         TaggedFlatObjectStyle ->
           prettyTypeDoc noIndent doc []
             ++ prettyAnnotations Nothing noIndent (dontAddParcelizeToSealedClasses anns)
-            ++ "sealed class "
+            ++ "sealed interface "
             ++ classTyp
             ++ prettyInterfaces ifaces
         TaggedObjectStyle ->
@@ -335,7 +333,7 @@ prettyEnum doc anns ifaces name tyVars cases sop@SumOfProductEncodingOptions {..
               Nothing
               noIndent
               (dontAddParcelizeToSealedClasses (sumAnnotations ++ anns))
-            ++ "sealed class "
+            ++ "sealed interface "
             ++ classTyp
             ++ prettyInterfaces ifaces
             ++ " {\n"


### PR DESCRIPTION
`sealed class` is unnecessary as these types never have constructor arguments. There used to be limitations on the kotlinx.serialization side, but those have been lifted for years now.