### PR TITLE
Kotlin: Fix codegen for single-nullary-constructor types

### DIFF
--- a/.golden/kotlinDataSingleNullarySpec/golden
+++ b/.golden/kotlinDataSingleNullarySpec/golden
@@ -1,1 +1,3 @@
-data class Data()
+@Parcelize
+@Serializable
+data object Data : Parcelable

--- a/.golden/kotlinDataSingleNullarySpec/golden
+++ b/.golden/kotlinDataSingleNullarySpec/golden
@@ -1,0 +1,1 @@
+data class Data()

--- a/.golden/kotlinDataSingleNullaryWithTypeVariableSpec/golden
+++ b/.golden/kotlinDataSingleNullaryWithTypeVariableSpec/golden
@@ -1,0 +1,3 @@
+@Parcelize
+@Serializable
+class Data<A : Parcelable> : Parcelable

--- a/.golden/swiftDataSingleNullarySpec/golden
+++ b/.golden/swiftDataSingleNullarySpec/golden
@@ -1,0 +1,1 @@
+struct Data {}

--- a/.golden/swiftDataSingleNullarySpec/golden
+++ b/.golden/swiftDataSingleNullarySpec/golden
@@ -1,1 +1,1 @@
-struct Data {}
+struct Data: Hashable, Codable {}

--- a/.golden/swiftDataSingleNullaryWithTypeVariableSpec/golden
+++ b/.golden/swiftDataSingleNullaryWithTypeVariableSpec/golden
@@ -1,0 +1,1 @@
+struct Data<A: Hashable & Codable>: Hashable, Codable {}

--- a/moat.cabal
+++ b/moat.cabal
@@ -86,6 +86,7 @@ test-suite spec
       GenericNewtypeSpec
       GenericStructSpec
       MultipleTypeVariableSpec
+      SingleNullarySpec
       StrictEnumsSpec
       StrictFieldsSpec
       SumOfProductDocSpec

--- a/moat.cabal
+++ b/moat.cabal
@@ -87,6 +87,7 @@ test-suite spec
       GenericStructSpec
       MultipleTypeVariableSpec
       SingleNullarySpec
+      SingleNullaryWithTypeVariableSpec
       StrictEnumsSpec
       StrictFieldsSpec
       SumOfProductDocSpec

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -18,15 +18,14 @@ import Moat.Types
 prettyKotlinData :: MoatData -> String
 prettyKotlinData = \case
   MoatStruct {..} ->
-    prettyTypeDoc noIndent structDoc structFields
-      ++ prettyAnnotations Nothing noIndent structAnnotations
-      ++ "data class "
-      ++ prettyMoatTypeHeader structName (addTyVarBounds structTyVars structInterfaces)
-      ++ "("
-      ++ newlineNonEmpty structFields
-      ++ prettyStructFields indents structFields
-      ++ ")"
-      ++ prettyInterfaces structInterfaces
+    prettyStruct
+      structName
+      structDoc
+      structTyVars
+      structInterfaces
+      structAnnotations
+      structFields
+      indents
   MoatEnum {..} ->
     prettyEnum
       enumDoc
@@ -273,6 +272,42 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
 
     objectParentTypeHeader :: String
     objectParentTypeHeader = prettyMoatTypeHeader parentName (replicate (length tyVars) "Nothing")
+
+prettyStruct ::
+  () =>
+  -- | name
+  String ->
+  -- | doc
+  Maybe String ->
+  -- | ty vars
+  [String] ->
+  -- | interfaces
+  [Interface] ->
+  -- | annotations
+  [Annotation] ->
+  -- | fields
+  [Field] ->
+  -- | indents
+  String ->
+  String
+prettyStruct name doc tyVars ifaces anns fields indents =
+  prettyTypeDoc noIndent doc fields
+    ++ prettyAnnotations Nothing noIndent anns
+    ++ body
+    ++ prettyInterfaces ifaces
+  where
+    body :: String
+    body =
+      case fields of
+        [] -> case tyVars of
+          [] -> "data object " ++ prettyMoatTypeHeader name []
+          _ -> "class " ++ prettyMoatTypeHeader name (addTyVarBounds tyVars ifaces)
+        _ ->
+          "data class "
+            ++ prettyMoatTypeHeader name (addTyVarBounds tyVars ifaces)
+            ++ "(\n"
+            ++ prettyStructFields indents fields
+            ++ ")"
 
 prettyEnum ::
   () =>

--- a/test/SingleNullarySpec.hs
+++ b/test/SingleNullarySpec.hs
@@ -1,0 +1,20 @@
+module SingleNullarySpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Data = DataCons
+
+mobileGen ''Data
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SingleNullarySpec"
+    it "kotlin" $
+      defaultGolden ("kotlinData" <> moduleName) (showKotlin @Data)
+    it "swift" $
+      defaultGolden ("swiftData" <> moduleName) (showSwift @Data)

--- a/test/SingleNullaryWithTypeVariableSpec.hs
+++ b/test/SingleNullaryWithTypeVariableSpec.hs
@@ -1,4 +1,4 @@
-module SingleNullarySpec where
+module SingleNullaryWithTypeVariableSpec where
 
 import Common
 import Moat
@@ -6,7 +6,7 @@ import Test.Hspec
 import Test.Hspec.Golden
 import Prelude hiding (Enum)
 
-data Data = DataCons
+data Data a = DataCons
 
 mobileGenWith
   ( defaultOptions
@@ -20,8 +20,8 @@ mobileGenWith
 spec :: Spec
 spec =
   describe "stays golden" $ do
-    let moduleName = "SingleNullarySpec"
+    let moduleName = "SingleNullaryWithTypeVariableSpec"
     it "kotlin" $
-      defaultGolden ("kotlinData" <> moduleName) (showKotlin @Data)
+      defaultGolden ("kotlinData" <> moduleName) (showKotlin @(Data Int))
     it "swift" $
-      defaultGolden ("swiftData" <> moduleName) (showSwift @Data)
+      defaultGolden ("swiftData" <> moduleName) (showSwift @(Data Int))


### PR DESCRIPTION
For a single-nullary-constructor type such as:

```haskell
data Data = DataCons
```

we're generating:

```kotlin
data class Data()
```

which isn't legal syntax. What it should be:

```kotlin
data object Data
```