### PR TITLE
Kotlin: Prevent name collisions between sum cases and contents field types

### DIFF
--- a/.golden/kotlinEnumSumOfProductWithNameCollisionSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithNameCollisionSpec/golden
@@ -1,0 +1,18 @@
+@JsonClassDiscriminator("tag")
+@Serializable
+sealed interface Enum : Parcelable {
+    @Parcelize
+    @Serializable
+    @SerialName("record0")
+    data class Record0(val contents: Record0) : Enum
+
+    @Parcelize
+    @Serializable
+    @SerialName("record1")
+    data class Record1(val contents: Record1) : Enum
+
+    @Parcelize
+    @Serializable
+    @SerialName("record2")
+    data object Record2 : Enum
+}

--- a/.golden/kotlinEnumSumOfProductWithNameCollisionSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithNameCollisionSpec/golden
@@ -4,12 +4,12 @@ sealed interface Enum : Parcelable {
     @Parcelize
     @Serializable
     @SerialName("record0")
-    data class Record0(val contents: Record0) : Enum
+    data class Record0_(val contents: Record0) : Enum
 
     @Parcelize
     @Serializable
     @SerialName("record1")
-    data class Record1(val contents: Record1) : Enum
+    data class Record1_(val contents: Record1) : Enum
 
     @Parcelize
     @Serializable

--- a/.golden/swiftEnumSumOfProductWithNameCollisionSpec/golden
+++ b/.golden/swiftEnumSumOfProductWithNameCollisionSpec/golden
@@ -1,0 +1,42 @@
+enum Enum: Codable {
+    case record0(Record0)
+    case record1(Record1)
+    case record2
+
+    enum CodingKeys: String, CodingKey {
+        case tag
+        case contents
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .tag)
+        switch discriminator {
+            case "record0":
+                self = .record0(try container.decode(Record0.self, forKey: .contents))
+            case "record1":
+                self = .record1(try container.decode(Record1.self, forKey: .contents))
+            case "record2":
+                self = .record2
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Enum.\(discriminator)")
+                )
+        }
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case let .record0(contents):
+                try container.encode("record0", forKey: .tag)
+                try container.encode(contents, forKey: .contents)
+            case let .record1(contents):
+                try container.encode("record1", forKey: .tag)
+                try container.encode(contents, forKey: .contents)
+            case .record2:
+                try container.encode("record2", forKey: .tag)
+        }
+    }
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -92,6 +92,7 @@ test-suite spec
       StrictFieldsSpec
       SumOfProductDocSpec
       SumOfProductSpec
+      SumOfProductWithNameCollisionSpec
       SumOfProductWithTaggedFlatObjectStyleSpec
       SumOfProductWithTaggedObjectAndNonConcreteCasesSpec
       SumOfProductWithTaggedObjectAndSingleNullarySpec

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -289,7 +289,8 @@ prettyTaggedObject parentName tyVars anns ifaces cases indents SumOfProductEncod
                         <> " can have zero or one concrete type constructor when using TaggedObjectStyle!"
                   -- Flat objects include their fields inline.
                   TaggedFlatObjectStyle ->
-                    prettyAnnotations (Just caseNm) indents anns
+                    prettyTypeDoc indents caseDoc fields
+                      ++ prettyAnnotations (Just caseNm) indents anns
                       ++ indents
                       ++ "data class "
                       ++ caseTypeHeader caseNm

--- a/test/SumOfProductWithNameCollisionSpec.hs
+++ b/test/SumOfProductWithNameCollisionSpec.hs
@@ -1,0 +1,68 @@
+module SumOfProductWithNameCollisionSpec where
+
+import Common
+import Data.List (stripPrefix)
+import Data.Maybe
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Record0 = Record0
+  { record0Field0 :: Int
+  , record0Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable]
+      , dataInterfaces = [Parcelable]
+      , dataProtocols = [Codable]
+      }
+  )
+  ''Record0
+
+data Record1 = Record1
+  { record1Field0 :: Int
+  , record1Field1 :: Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { dataAnnotations = [Parcelize, Serializable]
+      , dataInterfaces = [Parcelable]
+      , dataProtocols = [Codable]
+      }
+  )
+  ''Record1
+
+data Enum
+  = EnumRecord0 Record0
+  | EnumRecord1 Record1
+  | EnumRecord2
+
+mobileGenWith
+  ( defaultOptions
+      { constructorModifier = \body -> fromMaybe body (stripPrefix "Enum" body)
+      , dataAnnotations = [Parcelize, Serializable, SerialName]
+      , dataInterfaces = [Parcelable]
+      , dataProtocols = [Codable]
+      , sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle
+            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , contentsFieldName = "contents"
+            , tagFieldName = "tag"
+            }
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithNameCollisionSpec"
+    it "kotlin" $
+      defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)
+    it "swift" $
+      defaultGolden ("swiftEnum" <> moduleName) (showSwift @Enum)


### PR DESCRIPTION
A sum case like:

```kotlin
sealed interface SupportHoliday {
    data class BankHoliday(val contents: BankHoliday) : SupportHoliday
}
```

won't compile even if `BankHoliday` exists externally, because the type is recursive in its lexical scope.

Disambiguate these cases by appending underscores (`_`) to the case type's name.