### PR TITLE
Swift: Omit type variables for aliases

### DIFF
--- a/.golden/kotlinGenericAliasSpec/golden
+++ b/.golden/kotlinGenericAliasSpec/golden
@@ -1,1 +1,1 @@
-typealias TreeResponse<a> = Tree<a>
+typealias TreeResponse<A> = Tree<A>

--- a/.golden/kotlinGenericAliasSpec/golden
+++ b/.golden/kotlinGenericAliasSpec/golden
@@ -1,0 +1,1 @@
+typealias TreeResponse<a> = Tree<a>

--- a/.golden/swiftGenericAliasSpec/golden
+++ b/.golden/swiftGenericAliasSpec/golden
@@ -1,0 +1,1 @@
+typealias TreeResponse = Tree

--- a/moat.cabal
+++ b/moat.cabal
@@ -83,6 +83,7 @@ test-suite spec
       DuplicateRecordFieldSpec
       EnumValueClassDocSpec
       EnumValueClassSpec
+      GenericAliasSpec
       GenericNewtypeSpec
       GenericStructSpec
       MultipleTypeVariableSpec

--- a/src/Moat/Pretty/Kotlin.hs
+++ b/src/Moat/Pretty/Kotlin.hs
@@ -137,7 +137,7 @@ prettyValueClassInstances indents typ cons enumCases = case enumCases of
 
 prettyMoatTypeHeader :: String -> [String] -> String
 prettyMoatTypeHeader name [] = name
-prettyMoatTypeHeader name tyVars = name ++ "<" ++ intercalate ", " tyVars ++ ">"
+prettyMoatTypeHeader name tyVars = name ++ "<" ++ intercalate ", " (map toUpperFirst tyVars) ++ ">"
 
 -- | This function will take a name and the indentation level and render
 -- annotations in the style '@{string}\n...'. The name parameter is only used
@@ -196,7 +196,7 @@ prettyMoatType = \case
   F64 -> "Double"
   Decimal -> "Decimal"
   BigInt -> "BigInteger"
-  Poly ty -> ty
+  Poly ty -> toUpperFirst ty
   Concrete ty [] -> ty
   Concrete ty tys ->
     ty

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -61,9 +61,10 @@ prettySwiftDataWith indent = \case
   MoatAlias {..} ->
     prettyTypeDoc "" aliasDoc []
       ++ "typealias "
-      ++ prettyMoatTypeHeader aliasName (addTyVarBounds aliasTyVars [])
+      -- Swift aliases should not declare type parameters
+      ++ prettyMoatTypeHeader aliasName []
       ++ " = "
-      ++ prettyMoatType aliasTyp
+      ++ prettyMoatTypeBase aliasTyp
   MoatNewtype {..} ->
     prettyTypeDoc "" newtypeDoc []
       ++ "struct "
@@ -210,6 +211,15 @@ prettyMoatType = \case
       ++ intercalate ", " (map prettyMoatType tys)
       ++ ">"
   Tag {..} -> tagParent ++ "." ++ tagName
+
+-- | Pretty-print a 'MoatType', omitting type parameters.
+prettyMoatTypeBase :: MoatType -> String
+prettyMoatTypeBase = \case
+  Result _ _ -> "Result"
+  Set _ -> "Set"
+  Dictionary _ _ -> "Dictionary"
+  Concrete ty _ -> ty
+  ty -> prettyMoatType ty
 
 prettyApp :: MoatType -> MoatType -> String
 prettyApp t1 t2 =

--- a/test/GenericAliasSpec.hs
+++ b/test/GenericAliasSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module GenericAliasSpec where
+
+import Common
+import Data.List.NonEmpty (NonEmpty)
+import Data.Proxy
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude
+
+newtype TreeResponse a = TreeResponse (NonEmpty a)
+  deriving stock (Show, Eq)
+
+instance ToMoatType a => ToMoatType (TreeResponse a) where
+  toMoatType _ = Concrete "TreeResponse" [toMoatType (Proxy @a)]
+
+instance ToMoatData (TreeResponse a) where
+  toMoatData _ =
+    MoatAlias
+      { aliasName = "TreeResponse"
+      , aliasDoc = Nothing
+      , aliasTyVars = ["a"]
+      , aliasTyp = Concrete "Tree" [Poly "a"]
+      }
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "GenericAliasSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @(TreeResponse _))
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @(TreeResponse _))


### PR DESCRIPTION
Typealiases in Swift should not declare type parameters.