### PR TITLE
Record-wrapping newtypes should produce MoatStruct

### DIFF
--- a/.golden/kotlinAdvancedNewtypeWithEnumFieldSpec/golden
+++ b/.golden/kotlinAdvancedNewtypeWithEnumFieldSpec/golden
@@ -1,1 +1,3 @@
-value class Newtype(val newtypeField: Enum)
+data class Newtype(
+    val newtypeField: Enum,
+)

--- a/.golden/kotlinBasicNewtypeWithConcreteFieldSpec/golden
+++ b/.golden/kotlinBasicNewtypeWithConcreteFieldSpec/golden
@@ -1,1 +1,3 @@
-value class Newtype(val newtypeField: String)
+data class Newtype(
+    val newtypeField: String,
+)

--- a/.golden/kotlinBasicNewtypeWithEitherFieldSpec/golden
+++ b/.golden/kotlinBasicNewtypeWithEitherFieldSpec/golden
@@ -1,1 +1,3 @@
-value class Newtype(val newtypeField: Either<String, Int>)
+data class Newtype(
+    val newtypeField: Either<String, Int>,
+)

--- a/.golden/swiftAdvancedNewtypeWithEnumFieldSpec/golden
+++ b/.golden/swiftAdvancedNewtypeWithEnumFieldSpec/golden
@@ -1,3 +1,3 @@
 struct Newtype {
-    let newtypeField: Enum
+    var newtypeField: Enum
 }

--- a/.golden/swiftBasicNewtypeWithConcreteFieldSpec/golden
+++ b/.golden/swiftBasicNewtypeWithConcreteFieldSpec/golden
@@ -1,4 +1,3 @@
 struct Newtype {
-    typealias NewtypeTag = Tagged<Newtype, String>
-    let newtypeField: NewtypeTag
+    var newtypeField: String
 }

--- a/.golden/swiftBasicNewtypeWithEitherFieldSpec/golden
+++ b/.golden/swiftBasicNewtypeWithEitherFieldSpec/golden
@@ -1,4 +1,3 @@
 struct Newtype {
-    typealias NewtypeTag = Tagged<Newtype, Result<Int, String>>
-    let newtypeField: NewtypeTag
+    var newtypeField: Result<Int, String>
 }


### PR DESCRIPTION
Example:

```haskell
newtype Newtype = Newtype {newtypeField :: Text}
```

Aeson serializes this as a JSON object like:

```json
{"newtypeField":"foo"}
```

But Moat generates Kotlin code that deserializes this as its wrapped value, so we expect `"foo"` on the wire. The Mercury codebase has a ton of `newtypeToStruct` calls to coerce these into MoatStruct, and backend engs don't really know about this nuance so it's forgotten.

This changes `mkNewtype` to produce a `MoatStruct` if the wrapped constructor is a record constructor. In addition, this lifts the restriction that newtypes can't wrap records with multiple fields.

I am not sure if this breaks Swift codegen. If I'm correct about Aeson's output, then generating untagged structs shouldn't make a difference.