### PR TITLE
Add deprecated fields support

### DIFF
--- a/.golden/kotlinDeprecatedFieldSpec/golden
+++ b/.golden/kotlinDeprecatedFieldSpec/golden
@@ -1,0 +1,5 @@
+data class Data(
+    val field0: Int,
+// Deprecated since build 500
+//    val field1: Int? = null,
+)

--- a/.golden/swiftDeprecatedFieldSpec/golden
+++ b/.golden/swiftDeprecatedFieldSpec/golden
@@ -1,0 +1,5 @@
+struct Data {
+    var field0: Int
+// Deprecated since build 500
+//    var field1: Int?
+}

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -80,6 +80,7 @@ test-suite spec
       BasicNewtypeWithEitherFieldSpec
       BasicRecordSpec
       Common
+      DeprecatedFieldSpec
       DuplicateRecordFieldSpec
       EnumValueClassDocSpec
       EnumValueClassSpec

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -144,6 +144,7 @@ data MoatData
       --   populated by setting 'makeBase'.
       --
       --   Only used by the Swift backend.
+      , structDeprecatedFields :: [(String, Maybe String)]
       , structTags :: [MoatType]
       -- ^ The tags of the struct. See 'Tag'.
       --
@@ -418,6 +419,13 @@ data Options = Options
   --
   -- This can be used with @omitFields = const Discard@ to ensure fields are
   -- retained for client compatibility.
+  , deprecatedFields :: [(String, Maybe String)]
+  -- ^ These fields are deprecated for clients and a comment with details about the deprecation
+  -- deprecated fields are also required in Haskell
+  --
+  -- This field will generate a mobile type as a comment instead of actual code
+  -- and add the specified comment to the resulting type
+  -- The purpose of this field is to allow fields to be no longer generated
   , strictCases :: [String]
   -- ^ These enum cases are relied upon and must exist in the sum type.
   --
@@ -574,6 +582,7 @@ defaultOptions =
     , omitFields = const Keep
     , omitCases = const Keep
     , fieldsRequiredByClients = []
+    , deprecatedFields = []
     , strictCases = []
     , makeBase = (False, Nothing, [])
     , optionalExpand = False

--- a/test/DeprecatedFieldSpec.hs
+++ b/test/DeprecatedFieldSpec.hs
@@ -1,0 +1,29 @@
+module DeprecatedFieldSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+
+data Data = Data
+  { field0 :: Int
+  , field1 :: Maybe Int
+  }
+
+mobileGenWith
+  ( defaultOptions
+      { fieldsRequiredByClients = ["field0", "field1"]
+      , omitFields = const Discard
+      , deprecatedFields = [("field1", Just "Deprecated since build 500")]
+      }
+  )
+  ''Data
+
+spec :: Spec
+spec =
+  fdescribe "stays golden" $ do
+    let moduleName = "DeprecatedFieldSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @Data)
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @Data)


### PR DESCRIPTION
Adds support for the concept of "deprecated fields" - fields which are still required by older clients but we no longer want to generate on newer ones.

These fields will be:
- Required in the Haskell type
- Commented out on generated code