### PR TITLE
Add Sendable support

### DIFF
--- a/.golden/swiftGenericStructSpec/golden
+++ b/.golden/swiftGenericStructSpec/golden
@@ -1,4 +1,4 @@
-public struct Tree<A: Hashable & Codable>: Hashable, Codable {
+public struct Tree<A: Hashable & Codable & Sendable>: Hashable, Codable, Sendable {
     public var rootLabel: A
     public var subForest: [Tree<A>]
 

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -123,6 +123,7 @@ prettyProtocol = \case
   Hashable -> "Hashable"
   Codable -> "Codable"
   Equatable -> "Equatable"
+  Sendable -> "Sendable"
   OtherProtocol s -> s
 
 prettyProtocols :: [Protocol] -> String
@@ -641,11 +642,12 @@ onLast f (x : xs) = x : map f xs
 --   parameters.
 --
 --   This is needed for protocols with compiler-synthesized implementations
---   (similar to 'deriving stock'), of which there are currently three:
+--   (similar to 'deriving stock'), of which there are currently four:
 --
 --   - 'Equatable'
 --   - 'Hashable'
 --   - 'Codable'
+--   - 'Sendable'
 --
 --   See the [Swift documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols#Adopting-a-Protocol-Using-a-Synthesized-Implementation).
 addTyVarBounds :: [String] -> [Protocol] -> [String]
@@ -655,6 +657,7 @@ addTyVarBounds tyVars protos =
         Hashable -> True
         Codable -> True
         Equatable -> True
+        Sendable -> True
         OtherProtocol _ -> False
       synthesizedProtos = filter isSynthesized protos
       bounds = ": " ++ intercalate " & " (map prettyProtocol synthesizedProtos)

--- a/src/Moat/Types.hs
+++ b/src/Moat/Types.hs
@@ -287,6 +287,9 @@ data Protocol
   | -- | The 'Equatable' protocol.
     --   See https://developer.apple.com/documentation/swift/equatable
     Equatable
+  | -- | The 'Sendable' protocol.
+    --   See https://developer.apple.com/documentation/swift/sendable
+    Sendable
   | -- | A user-specified protocol.
     OtherProtocol String
   deriving stock (Eq, Read, Show, Generic)

--- a/test/GenericStructSpec.hs
+++ b/test/GenericStructSpec.hs
@@ -12,7 +12,7 @@ import Prelude
 mobileGenWith
   ( defaultOptions
       { dataInterfaces = [Parcelable]
-      , dataProtocols = [Hashable, Codable]
+      , dataProtocols = [Hashable, Codable, Sendable]
       , generateDocComments = False
       }
   )


### PR DESCRIPTION
Add Sendable support. It's safe to add for any types generated by Moat since they're all value types.