### PR TITLE
fix: Bind field names in prettyEnumCoding

### DIFF
--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -593,7 +593,9 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
               _ ->
                 "case let ."
                   ++ enumCaseName
-                  ++ ":"
+                  ++ "("
+                  ++ (intercalate ", " ( enumCaseFields <&> \(Field {..}) -> fieldName))
+                  ++ "):"
                   ++ indent
                     ( "try container.encode(\""
                         ++ enumCaseName


### PR DESCRIPTION
The previously produced code didn't bind the field names in the enum case, leading to compile errors

== Example

For

```haskell
data Keyword
  = RawKw Text
  | InstanceLabelKw
  | RefKw { refKwDefName :: Text
          , refKwQuery   :: Query Void
          }
```

The diff in generated code is:
```diff
    public func encode(to encoder: any Encoder) throws {
        var container = encoder.container(keyedBy: CodingKeys.self)
        switch (self) {
            case let .rawKw(value):
                try container.encode("rawKw", forKey: .tag)
                try value.encode(to: encoder)
            case .instanceLabelKw:
                try container.encode("instanceLabelKw", forKey: .tag)
-           case let .refKw:
+           case let .refKw(refKwDefName, refKwQuery):
                try container.encode("refKw", forKey: .tag)
                try container.encode(refKwDefName, forKey: .refKwDefName)
                try container.encode(refKwQuery, forKey: .refKwQuery)
        }
    }
```