### PR TITLE
Pin actions to hashes using pinact [workflow-enforcer]

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,8 +9,8 @@ jobs:
   generate-readme:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v19
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49 # v19
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,15 +21,15 @@ jobs:
     env:
       CONFIG: "--enable-tests"
     steps:
-      - uses: actions/checkout@v3
-      - uses: haskell-actions/setup@v2.5.1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: haskell-actions/setup@f7d8a55550ba6c8e4fdba2f1e56e14f595218dd9 # v2.5.1
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-update: false
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
-      - uses: actions/cache@v3
+      - uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # v3.4.3
         with:
           path: |
             ${{ steps.setup-haskell-cabal.outputs.cabal-store }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,8 +24,8 @@ jobs:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.ghc }}
       cancel-in-progress: true
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v19
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+    - uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49 # v19
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |


### PR DESCRIPTION
This PR pins action references to commit hashes to mitigate supply chain attacks where a bad actor will push a new tag or override an existing tag, leading to us running malicious code immediately without explicitly updating.

Documentation on how to use pinact can be found in the internal developers site.
