### PR TITLE
Swift: Ensure all enum case labels are lowercased

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,10 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         ghc:
-          - ghc90
-          - ghc92
-          - ghc94
           - ghc96
+          - ghc910
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ matrix.ghc }}
       cancel-in-progress: true

--- a/.golden/kotlinEnumSumOfProductWithUpperCaseTagsSpec/golden
+++ b/.golden/kotlinEnumSumOfProductWithUpperCaseTagsSpec/golden
@@ -1,0 +1,13 @@
+@JsonClassDiscriminator("tag")
+@Serializable
+sealed interface Enum : Parcelable {
+    @Parcelize
+    @Serializable
+    @SerialName("DataCons0")
+    data object DataCons0 : Enum
+
+    @Parcelize
+    @Serializable
+    @SerialName("DataCons1")
+    data class DataCons1(val contents: Record1) : Enum
+}

--- a/.golden/kotlinEnumUpperCaseLabelsSpec/golden
+++ b/.golden/kotlinEnumUpperCaseLabelsSpec/golden
@@ -1,0 +1,5 @@
+enum class Enum {
+    AliceInChains,
+    BlindMelon,
+    Candlebox,
+}

--- a/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord0DuplicateRecordFieldSpec/golden
@@ -1,6 +1,7 @@
 /**
  * Record 0 with duplicate fields
  *
+ * @param field0 duplicate field0
  * @param field1 not a duplicate
  */
 data class Data0(

--- a/.golden/kotlinRecord0DuplicateRecordFieldSpecNoFieldDoc/golden
+++ b/.golden/kotlinRecord0DuplicateRecordFieldSpecNoFieldDoc/golden
@@ -1,0 +1,9 @@
+/**
+ * Record 0 with duplicate fields
+ *
+ * @param field1 not a duplicate
+ */
+data class Data0(
+    val field0: Int,
+    val field1: Int? = null,
+)

--- a/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/kotlinRecord1DuplicateRecordFieldSpec/golden
@@ -1,6 +1,7 @@
 /**
  * Record 1 with duplicate fields
  *
+ * @param field0 duplicate field0
  * @param field2 not a duplicate
  */
 data class Data1(

--- a/.golden/kotlinRecord1DuplicateRecordFieldSpecNoFieldDoc/golden
+++ b/.golden/kotlinRecord1DuplicateRecordFieldSpecNoFieldDoc/golden
@@ -1,0 +1,9 @@
+/**
+ * Record 1 with duplicate fields
+ *
+ * @param field2 not a duplicate
+ */
+data class Data1(
+    val field0: String,
+    val field2: String? = null,
+)

--- a/.golden/swiftAdvancedEnumSpec/golden
+++ b/.golden/swiftAdvancedEnumSpec/golden
@@ -1,4 +1,4 @@
-public enum Enum: CaseIterable, Hashable, Codable {
+public enum Enum: String, CaseIterable, Hashable, Codable {
     case a
     case b
     case c

--- a/.golden/swiftBasicEnumSpec/golden
+++ b/.golden/swiftBasicEnumSpec/golden
@@ -1,4 +1,4 @@
-public enum Enum {
+public enum Enum: String, Codable {
     case a
     case b
     case c

--- a/.golden/swiftBasicEnumWithRawValueSpec/golden
+++ b/.golden/swiftBasicEnumWithRawValueSpec/golden
@@ -1,4 +1,4 @@
-public enum Enum {
+public enum Enum: String, Codable {
     case a
     case b
 }

--- a/.golden/swiftEnumSumOfProductSpec/golden
+++ b/.golden/swiftEnumSumOfProductSpec/golden
@@ -35,11 +35,11 @@ public enum Enum: Hashable, Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch (self) {
-            case let .dataCons0:
+            case let .dataCons0(enumField0, enumField1):
                 try container.encode("dataCons0", forKey: .tag)
                 try container.encode(enumField0, forKey: .enumField0)
                 try container.encode(enumField1, forKey: .enumField1)
-            case let .dataCons1:
+            case let .dataCons1(enumField2, enumField3):
                 try container.encode("dataCons1", forKey: .tag)
                 try container.encode(enumField2, forKey: .enumField2)
                 try container.encode(enumField3, forKey: .enumField3)

--- a/.golden/swiftEnumSumOfProductWithUpperCaseTagsSpec/golden
+++ b/.golden/swiftEnumSumOfProductWithUpperCaseTagsSpec/golden
@@ -1,0 +1,36 @@
+public enum Enum: Hashable, Codable {
+    case DataCons0
+    case DataCons1(Record1)
+
+    public enum CodingKeys: String, CodingKey {
+        case tag
+        case contents
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .tag)
+        switch discriminator {
+            case "DataCons0":
+                self = .DataCons0
+            case "DataCons1":
+                self = .DataCons1(try container.decode(Record1.self, forKey: .contents))
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Enum.\(discriminator)")
+                )
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case .DataCons0:
+                try container.encode("DataCons0", forKey: .tag)
+            case let .DataCons1(contents):
+                try container.encode("DataCons1", forKey: .tag)
+                try container.encode(contents, forKey: .contents)
+        }
+    }
+}

--- a/.golden/swiftEnumSumOfProductWithUpperCaseTagsSpec/golden
+++ b/.golden/swiftEnumSumOfProductWithUpperCaseTagsSpec/golden
@@ -1,6 +1,6 @@
 public enum Enum: Hashable, Codable {
-    case DataCons0
-    case DataCons1(Record1)
+    case dataCons0
+    case dataCons1(Record1)
 
     public enum CodingKeys: String, CodingKey {
         case tag
@@ -12,9 +12,9 @@ public enum Enum: Hashable, Codable {
         let discriminator = try container.decode(String.self, forKey: .tag)
         switch discriminator {
             case "DataCons0":
-                self = .DataCons0
+                self = .dataCons0
             case "DataCons1":
-                self = .DataCons1(try container.decode(Record1.self, forKey: .contents))
+                self = .dataCons1(try container.decode(Record1.self, forKey: .contents))
             default:
                 throw DecodingError.typeMismatch(
                     CodingKeys.self,
@@ -26,9 +26,9 @@ public enum Enum: Hashable, Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch (self) {
-            case .DataCons0:
+            case .dataCons0:
                 try container.encode("DataCons0", forKey: .tag)
-            case let .DataCons1(contents):
+            case let .dataCons1(contents):
                 try container.encode("DataCons1", forKey: .tag)
                 try container.encode(contents, forKey: .contents)
         }

--- a/.golden/swiftEnumUpperCaseLabelsSpec/golden
+++ b/.golden/swiftEnumUpperCaseLabelsSpec/golden
@@ -1,0 +1,5 @@
+public enum Enum: String, Codable {
+    case aliceInChains = "AliceInChains"
+    case blindMelon = "BlindMelon"
+    case candlebox = "Candlebox"
+}

--- a/.golden/swiftEnumValueClassDocSpec/golden
+++ b/.golden/swiftEnumValueClassDocSpec/golden
@@ -1,5 +1,5 @@
 /// Top-level enum documentation.
-public enum EnumAsValueClass: CaseIterable, Hashable, Codable {
+public enum EnumAsValueClass: String, CaseIterable, Hashable, Codable {
     /// ``First``
     case first
     /// ``Second``

--- a/.golden/swiftEnumValueClassSpec/golden
+++ b/.golden/swiftEnumValueClassSpec/golden
@@ -1,4 +1,4 @@
-public enum EnumAsValueClass: CaseIterable, Hashable, Codable {
+public enum EnumAsValueClass: String, CaseIterable, Hashable, Codable {
     case first
     case second
     case third

--- a/.golden/swiftExpressionEscapedKeywordsSpec/golden
+++ b/.golden/swiftExpressionEscapedKeywordsSpec/golden
@@ -1,0 +1,41 @@
+public enum Expression: Codable {
+    case `try`(_ `defer`: Int, _ `fallthrough`: String)
+    case `catch`
+
+    public enum CodingKeys: String, CodingKey {
+        case tag
+        case `defer`
+        case `fallthrough`
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let discriminator = try container.decode(String.self, forKey: .tag)
+        switch discriminator {
+            case "try":
+                self = .`try`(
+                    try container.decode(Int.self, forKey: .`defer`),
+                    try container.decode(String.self, forKey: .`fallthrough`)
+                )
+            case "catch":
+                self = .`catch`
+            default:
+                throw DecodingError.typeMismatch(
+                    CodingKeys.self,
+                    .init(codingPath: decoder.codingPath, debugDescription: "Can't decode unknown tag: Expression.\(discriminator)")
+                )
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch (self) {
+            case let .`try`(`defer`, `fallthrough`):
+                try container.encode("try", forKey: .tag)
+                try container.encode(`defer`, forKey: .`defer`)
+                try container.encode(`fallthrough`, forKey: .`fallthrough`)
+            case .`catch`:
+                try container.encode("catch", forKey: .tag)
+        }
+    }
+}

--- a/.golden/swiftKeywordEscapedKeywordsSpec/golden
+++ b/.golden/swiftKeywordEscapedKeywordsSpec/golden
@@ -1,0 +1,7 @@
+public enum Keyword: String, Codable {
+    case `case`
+    case `default`
+    case `class`
+    case `switch`
+    case `return`
+}

--- a/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord0DuplicateRecordFieldSpec/golden
@@ -1,5 +1,6 @@
 /// Record 0 with duplicate fields
 public struct Data0 {
+    /// duplicate field0
     public var field0: Int
     /// not a duplicate
     public var field1: Int?

--- a/.golden/swiftRecord0DuplicateRecordFieldSpecNoFieldDoc/golden
+++ b/.golden/swiftRecord0DuplicateRecordFieldSpecNoFieldDoc/golden
@@ -1,0 +1,11 @@
+/// Record 0 with duplicate fields
+public struct Data0 {
+    public var field0: Int
+    /// not a duplicate
+    public var field1: Int?
+
+    public init(field0: Int, field1: Int? = nil) {
+        self.field0 = field0
+        self.field1 = field1
+    }
+}

--- a/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
+++ b/.golden/swiftRecord1DuplicateRecordFieldSpec/golden
@@ -1,5 +1,6 @@
 /// Record 1 with duplicate fields
 public struct Data1 {
+    /// duplicate field0
     public var field0: String
     /// not a duplicate
     public var field2: String?

--- a/.golden/swiftRecord1DuplicateRecordFieldSpecNoFieldDoc/golden
+++ b/.golden/swiftRecord1DuplicateRecordFieldSpecNoFieldDoc/golden
@@ -1,0 +1,11 @@
+/// Record 1 with duplicate fields
+public struct Data1 {
+    public var field0: String
+    /// not a duplicate
+    public var field2: String?
+
+    public init(field0: String, field2: String? = nil) {
+        self.field0 = field0
+        self.field2 = field2
+    }
+}

--- a/.golden/swiftStrictEnumsSpec-EnumA/golden
+++ b/.golden/swiftStrictEnumsSpec-EnumA/golden
@@ -1,3 +1,3 @@
-public enum EnumA {
+public enum EnumA: String, Codable {
     case enumFirst
 }

--- a/.golden/swiftStrictEnumsSpec-EnumB/golden
+++ b/.golden/swiftStrictEnumsSpec-EnumB/golden
@@ -1,3 +1,3 @@
-public enum EnumB {
+public enum EnumB: String, Codable {
     case fourth
 }

--- a/.golden/swiftStructEscapedKeywordsSpec/golden
+++ b/.golden/swiftStructEscapedKeywordsSpec/golden
@@ -1,0 +1,11 @@
+public struct Struct: Codable {
+    public var `func`: Int
+    public var `static`: String
+    public var `public`: Bool
+
+    public init(`func`: Int, `static`: String, `public`: Bool) {
+        self.`func` = `func`
+        self.`static` = `static`
+        self.`public` = `public`
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ ghcid-test: hpack
 	ghcid -c cabal repl test:spec
 
 format:
-	alejandra --quiet .
+	nixfmt --quiet *.nix
 	fourmolu -i src/ test/
 
 check-format:
-	fourmolu -m check src/ test/ && alejandra --check .
+	fourmolu -m check src/ test/ && nixfmt --check *.nix
 
 hlint:
 	hlint .

--- a/default.nix
+++ b/default.nix
@@ -3,4 +3,4 @@ let
     src = ./.;
   };
 in
-  flake-compat.defaultNix
+flake-compat.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,16 @@
         "ghc910"
       ];
 
+      shells = [
+        "ghc96"
+        "ghc910"
+      ];
+
       eachSystem = nixpkgs.lib.genAttrs systems;
 
       eachHaskell = nixpkgs.lib.genAttrs haskells;
+
+      eachShell = nixpkgs.lib.genAttrs shells;
 
       latestHaskell = nixpkgs.lib.last haskells;
 
@@ -52,7 +59,7 @@
         let
           pkgs = pkgsBySystem.${system};
 
-          shells = eachHaskell (
+          shells = eachShell (
             haskell:
             let
               hsPkgs = haskellPackages.${system}.${haskell};

--- a/flake.nix
+++ b/flake.nix
@@ -5,57 +5,63 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-  }: let
-    systems = ["aarch64-darwin" "x86_64-darwin" "x86_64-linux"];
+  outputs =
+    {
+      self,
+      nixpkgs,
+    }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
 
-    haskells = ["ghc90" "ghc92" "ghc94" "ghc96"];
+      haskells = [
+        "ghc90"
+        "ghc92"
+        "ghc94"
+        "ghc96"
+        "ghc910"
+      ];
 
-    eachSystem = nixpkgs.lib.genAttrs systems;
+      eachSystem = nixpkgs.lib.genAttrs systems;
 
-    eachHaskell = nixpkgs.lib.genAttrs haskells;
+      eachHaskell = nixpkgs.lib.genAttrs haskells;
 
-    latestHaskell = nixpkgs.lib.last haskells;
+      latestHaskell = nixpkgs.lib.last haskells;
 
-    pkgsBySystem = eachSystem (system: nixpkgs.legacyPackages.${system});
+      pkgsBySystem = eachSystem (system: nixpkgs.legacyPackages.${system});
 
-    haskellPackages = eachSystem (
-      system:
-        eachHaskell (
-          haskell:
-            pkgsBySystem.${system}.haskell.packages.${haskell}
-        )
-    );
-  in {
-    packages = eachSystem (
-      system: let
-        moats =
-          nixpkgs.lib.mapAttrs'
-          (n: v: {
+      haskellPackages = eachSystem (
+        system: eachHaskell (haskell: pkgsBySystem.${system}.haskell.packages.${haskell})
+      );
+    in
+    {
+      packages = eachSystem (
+        system:
+        let
+          moats = nixpkgs.lib.mapAttrs' (n: v: {
             name = "moat-${n}";
             value = v;
-          })
-          (eachHaskell (
+          }) (eachHaskell (haskell: haskellPackages.${system}.${haskell}.callPackage ./moat.nix { }));
+        in
+        moats // { default = moats."moat-${latestHaskell}"; }
+      );
+
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = pkgsBySystem.${system};
+
+          shells = eachHaskell (
             haskell:
-              haskellPackages.${system}.${haskell}.callPackage ./moat.nix {}
-          ));
-      in
-        moats // {default = moats."moat-${latestHaskell}";}
-    );
-
-    devShells = eachSystem (
-      system: let
-        pkgs = pkgsBySystem.${system};
-
-        shells = eachHaskell (
-          haskell: let
-            hsPkgs = haskellPackages.${system}.${haskell};
-          in
+            let
+              hsPkgs = haskellPackages.${system}.${haskell};
+            in
             pkgs.mkShell {
               name = "moat-${haskell}-shell";
-              inputsFrom = [self.packages.${system}."moat-${haskell}"];
+              inputsFrom = [ self.packages.${system}."moat-${haskell}" ];
               nativeBuildInputs = [
                 hsPkgs.cabal2nix
                 hsPkgs.cabal-install
@@ -65,12 +71,12 @@
                 hsPkgs.hlint
                 hsPkgs.hpack
                 hsPkgs.fourmolu
-                pkgs.alejandra
+                pkgs.nixfmt
               ];
             }
-        );
-      in
-        shells // {default = shells.${latestHaskell};}
-    );
-  };
+          );
+        in
+        shells // { default = shells.${latestHaskell}; }
+      );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,6 @@
       ];
 
       haskells = [
-        "ghc90"
-        "ghc92"
         "ghc94"
         "ghc96"
         "ghc910"

--- a/moat.cabal
+++ b/moat.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.3.
 --
 -- see: https://github.com/sol/hpack
 

--- a/moat.cabal
+++ b/moat.cabal
@@ -44,19 +44,19 @@ library
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base >=4.11 && <4.19
-    , bytestring >=0.10 && <0.12
+      base >=4.11 && <4.22
+    , bytestring >=0.10 && <0.13
     , case-insensitive ==1.2.*
     , cmark-gfm >=0.2.5 && <0.3.0
-    , containers >=0.5.9 && <0.7
+    , containers >=0.5.9 && <0.9
     , haddock-library >=1.10 && <1.12
     , mtl >=2.2 && <2.4
-    , primitive >=0.6.4 && <0.9
-    , template-haskell >=2.11 && <2.21
-    , text >=1.2 && <2.1
-    , th-abstraction >=0.3 && <0.7
+    , primitive >=0.6.4 && <0.10
+    , template-haskell >=2.11 && <2.25
+    , text >=1.2 && <2.2
+    , th-abstraction >=0.3 && <0.8
     , th-compat >=0.1.0 && <0.2
-    , time >=1.8 && <1.13
+    , time >=1.8 && <2.0
     , unordered-containers ==0.2.*
     , uuid-types ==1.0.*
     , vector >=0.12 && <0.14
@@ -125,22 +125,22 @@ test-suite spec
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base >=4.11 && <4.19
-    , bytestring >=0.10 && <0.12
+      base >=4.11 && <4.22
+    , bytestring >=0.10 && <0.13
     , case-insensitive ==1.2.*
     , cmark-gfm >=0.2.5 && <0.3.0
-    , containers >=0.5.9 && <0.7
+    , containers >=0.5.9 && <0.9
     , haddock-library >=1.10 && <1.12
     , hspec
     , hspec-discover
     , hspec-golden
     , mtl >=2.2 && <2.4
-    , primitive >=0.6.4 && <0.9
-    , template-haskell >=2.11 && <2.21
-    , text >=1.2 && <2.1
-    , th-abstraction >=0.3 && <0.7
+    , primitive >=0.6.4 && <0.10
+    , template-haskell >=2.11 && <2.25
+    , text >=1.2 && <2.2
+    , th-abstraction >=0.3 && <0.8
     , th-compat >=0.1.0 && <0.2
-    , time >=1.8 && <1.13
+    , time >=1.8 && <2.0
     , unordered-containers ==0.2.*
     , uuid-types ==1.0.*
     , vector >=0.12 && <0.14

--- a/moat.cabal
+++ b/moat.cabal
@@ -85,6 +85,7 @@ test-suite spec
       EnumUpperCaseLabelsSpec
       EnumValueClassDocSpec
       EnumValueClassSpec
+      EscapedKeywordsSpec
       GenericAliasSpec
       GenericNewtypeSpec
       GenericStructSpec

--- a/moat.cabal
+++ b/moat.cabal
@@ -100,6 +100,7 @@ test-suite spec
       SumOfProductWithTaggedObjectAndSingleNullarySpec
       SumOfProductWithTaggedObjectStyleSpec
       SumOfProductWithTypeParameterSpec
+      SumOfProductWithUpperCaseTagsSpec
       TypeVariableSpec
       Moat
       Moat.Class

--- a/moat.cabal
+++ b/moat.cabal
@@ -82,6 +82,7 @@ test-suite spec
       Common
       DeprecatedFieldSpec
       DuplicateRecordFieldSpec
+      EnumUpperCaseLabelsSpec
       EnumValueClassDocSpec
       EnumValueClassSpec
       GenericAliasSpec

--- a/moat.nix
+++ b/moat.nix
@@ -43,7 +43,7 @@ mkDerivation {
     uuid-types
     vector
   ];
-  libraryToolDepends = [hspec-discover];
+  libraryToolDepends = [ hspec-discover ];
   testHaskellDepends = [
     base
     bytestring
@@ -65,7 +65,7 @@ mkDerivation {
     uuid-types
     vector
   ];
-  testToolDepends = [hspec-discover];
+  testToolDepends = [ hspec-discover ];
   homepage = "https://github.com/chessai/moat#readme";
   description = "Generate swift and kotlin types from haskell types";
   license = lib.licenses.mit;

--- a/package.yaml
+++ b/package.yaml
@@ -16,19 +16,19 @@ default-extensions:
   - RecordWildCards
 
 dependencies:
-  - base >= 4.11 && < 4.19
-  - bytestring >= 0.10 && < 0.12
+  - base >= 4.11 && < 4.22
+  - bytestring >= 0.10 && < 0.13
   - case-insensitive >= 1.2 && < 1.3
   - cmark-gfm >= 0.2.5 && < 0.3.0
-  - containers >= 0.5.9 && < 0.7
+  - containers >= 0.5.9 && < 0.9
   - haddock-library >= 1.10 && < 1.12
   - mtl >= 2.2 && < 2.4
-  - primitive >= 0.6.4 && < 0.9
-  - template-haskell >= 2.11 && < 2.21
-  - text >= 1.2 && < 2.1
-  - th-abstraction >= 0.3 && < 0.7
+  - primitive >= 0.6.4 && < 0.10
+  - template-haskell >= 2.11 && < 2.25
+  - text >= 1.2 && < 2.2
+  - th-abstraction >= 0.3 && < 0.8
   - th-compat >= 0.1.0 && < 0.2
-  - time >= 1.8 && < 1.13
+  - time >= 1.8 && < 2.0
   - unordered-containers >= 0.2 && < 0.3
   - uuid-types >= 1.0 && < 1.1
   - vector >= 0.12 && < 0.14

--- a/shell.nix
+++ b/shell.nix
@@ -3,4 +3,4 @@ let
     src = ./.;
   };
 in
-  flake-compat.shellNix
+flake-compat.shellNix

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -104,6 +104,9 @@ import qualified Data.Bifunctor as Bifunctor
 import Data.Bool (bool)
 import qualified Data.Char as Char
 import Data.Foldable (foldlM, foldr')
+#if !MIN_VERSION_base(4,20,0)
+import Data.Foldable (foldl')
+#endif
 import Data.Functor ((<&>))
 import qualified Data.List as L
 import Data.List.NonEmpty (NonEmpty (..), (<|))

--- a/src/Moat.hs
+++ b/src/Moat.hs
@@ -103,7 +103,7 @@ import Control.Monad.Trans
 import qualified Data.Bifunctor as Bifunctor
 import Data.Bool (bool)
 import qualified Data.Char as Char
-import Data.Foldable (foldl', foldlM, foldr')
+import Data.Foldable (foldlM, foldr')
 import Data.Functor ((<&>))
 import qualified Data.List as L
 import Data.List.NonEmpty (NonEmpty (..), (<|))
@@ -595,7 +595,7 @@ prettyTyVarBndrStr = \case
   PlainTV n -> go n
   KindedTV n _ -> go n
   where
-    go = TS.unpack . head . TS.splitOn "_" . last . TS.splitOn "." . TS.pack . show
+    go = TS.unpack . TS.takeWhile (/= '_') . last . TS.splitOn "." . TS.pack . show
 
 -- prettify the type and kind.
 prettyKindVar :: Type -> Either String (String, String)
@@ -604,7 +604,7 @@ prettyKindVar = \case
   VarT n -> Right (nameStr n, "*")
   typ -> Left $ "Moat.prettyKindVar: used on a type without a kind signature. Type was: " ++ show typ
   where
-    go = TS.unpack . head . TS.splitOn "_" . last . TS.splitOn "." . TS.pack . show . ppr
+    go = TS.unpack . TS.takeWhile (/= '_') . last . TS.splitOn "." . TS.pack . show . ppr
 
 type MoatM = ExceptT MoatError Q
 
@@ -1111,7 +1111,7 @@ unqualName = stringE . nameStr
 
 -- prettify a type variable as an Exp
 prettyTyVar :: Name -> Exp
-prettyTyVar = stringE . map Char.toUpper . TS.unpack . head . TS.splitOn "_" . last . TS.splitOn "." . TS.pack . show
+prettyTyVar = stringE . map Char.toUpper . TS.unpack . TS.takeWhile (/= '_') . last . TS.splitOn "." . TS.pack . show
 
 -- prettify a bunch of type variables as an Exp
 prettyTyVars :: [Type] -> Exp
@@ -1408,7 +1408,7 @@ toMoatTypeEPoly = \case
     AppE (ConE 'Poly) (prettyTyVar n)
   typ ->
     let decompressed = decompress typ
-        prettyName = map Char.toUpper . TS.unpack . head . TS.splitOn "_" . last . TS.splitOn "." . TS.pack . show
+        prettyName = map Char.toUpper . TS.unpack . TS.takeWhile (/= '_') . last . TS.splitOn "." . TS.pack . show
         filledInHoles =
           decompressed
             <&> ( \case

--- a/src/Moat/Pretty/Doc/Markdown.hs
+++ b/src/Moat/Pretty/Doc/Markdown.hs
@@ -57,7 +57,11 @@ markdownBlocks m i = \case
 
 #if MIN_VERSION_haddock_library(1,11,0)
 markdownOrderedList :: (String -> Node) -> (String -> Node) -> [(Int, DocH String String)] -> Node
-markdownOrderedList m i ds = ol (fst (head ds)) (map (markdownListItem m i . snd) ds)
+markdownOrderedList m i ds = ol start (map (markdownListItem m i . snd) ds)
+  where
+    start = case ds of
+      ((n, _) : _) -> n
+      [] -> 1
 #else
 markdownOrderedList :: (String -> Node) -> (String -> Node) -> [DocH String String] -> Node
 markdownOrderedList m i ds = ol 1 (map (markdownListItem m i) ds)

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -8,6 +8,7 @@ module Moat.Pretty.Swift
   )
 where
 
+import Data.Char (toLower)
 import Data.Functor ((<&>))
 import Data.List (intercalate, nub)
 import qualified Data.Map as Map
@@ -169,6 +170,13 @@ prettyTagDisambiguator disambiguate indents parent =
         ++ "Tag { }\n"
     else ""
 
+-- | Lowercase the first character of an enum case name to produce an
+--   idiomatic Swift case label. This only affects the Swift identifier; the
+--   tag encoded to and decoded from the wire is left untouched.
+swiftCaseLabel :: String -> String
+swiftCaseLabel "" = ""
+swiftCaseLabel (c : cs) = toLower c : cs
+
 labelCase :: Field -> String
 labelCase (Field "" ty _) = prettyMoatType ty
 labelCase (Field label ty _) = "_ " ++ label ++ ": " ++ prettyMoatType ty
@@ -246,21 +254,21 @@ prettyEnumCases indents unknown cases = go cases ++ unknownCase
         prettyTypeDoc indents caseDoc []
           ++ indents
           ++ "case "
-          ++ caseNm
+          ++ swiftCaseLabel caseNm
           ++ "\n"
           ++ go xs
       (EnumCase caseNm caseDoc cs : xs) ->
         prettyTypeDoc indents caseDoc cs
           ++ indents
           ++ "case "
-          ++ caseNm
+          ++ swiftCaseLabel caseNm
           ++ "("
           ++ intercalate ", " (map labelCase cs)
           ++ ")\n"
           ++ go xs
 
     unknownCase = case unknown of
-      Just caseNm -> indents ++ "case " ++ caseNm ++ "\n"
+      Just caseNm -> indents ++ "case " ++ swiftCaseLabel caseNm ++ "\n"
       Nothing -> ""
 
 prettyStructFields :: String -> [Field] -> [(String, Maybe String)] -> String
@@ -413,7 +421,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 ++ "\":"
                 ++ indent
                   ( "self = ."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                       ++ "(try container.decode("
                       ++ prettyMoatType caseTy
                       ++ ".self, forKey: ."
@@ -426,7 +434,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 ++ "\":"
                 ++ indent
                   ( "self = ."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                   )
             EnumCase caseNm _ _ ->
               error $
@@ -448,7 +456,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 ++ "\":"
                 ++ indent
                   ( "self = ."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                   )
             EnumCase caseNm _ [Field "" caseTy _] ->
               "case \""
@@ -456,7 +464,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 ++ "\":"
                 ++ indent
                   ( "self = ."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                       ++ "(try "
                       ++ prettyMoatType caseTy
                       ++ ".init(from: decoder))"
@@ -467,7 +475,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 ++ "\":"
                 ++ indent
                   ( "self = ."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                       ++ "("
                       ++ indent
                         ( intercalate
@@ -489,7 +497,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
     prettyInitUnknownCase = case unknownCase of
       Just caseNm ->
         "default:"
-          ++ indent ("self = ." ++ caseNm)
+          ++ indent ("self = ." ++ swiftCaseLabel caseNm)
       Nothing ->
         "default:"
           ++ indent
@@ -528,7 +536,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
             case enumCaseFields of
               [] ->
                 "case ."
-                  ++ enumCaseName
+                  ++ swiftCaseLabel enumCaseName
                   ++ ":"
                   ++ indent
                     ( "try container.encode(\""
@@ -539,7 +547,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                     )
               [Field "" _ _] ->
                 "case let ."
-                  ++ enumCaseName
+                  ++ swiftCaseLabel enumCaseName
                   ++ "("
                   ++ contentsFieldName
                   ++ "):"
@@ -569,7 +577,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
             case enumCaseFields of
               [] ->
                 "case ."
-                  ++ enumCaseName
+                  ++ swiftCaseLabel enumCaseName
                   ++ ":"
                   ++ indent
                     ( "try container.encode(\""
@@ -580,7 +588,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                     )
               [Field "" _ _] ->
                 "case let ."
-                  ++ enumCaseName
+                  ++ swiftCaseLabel enumCaseName
                   ++ "(value):"
                   ++ indent
                     ( "try container.encode(\""
@@ -592,7 +600,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                     )
               _ ->
                 "case let ."
-                  ++ enumCaseName
+                  ++ swiftCaseLabel enumCaseName
                   ++ ":"
                   ++ indent
                     ( "try container.encode(\""
@@ -617,7 +625,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
     prettyEncodeUnknownCase = case unknownCase of
       Just caseNm ->
         "case ."
-          ++ caseNm
+          ++ swiftCaseLabel caseNm
           ++ ":"
           ++ indent
             ( "throw EncodingError.invalidValue("
@@ -625,7 +633,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                   ( "self,\n.init(codingPath: encoder.codingPath, debugDescription: \"Can't encode value: "
                       ++ parentName
                       ++ "."
-                      ++ caseNm
+                      ++ swiftCaseLabel caseNm
                       ++ "\")"
                   )
                 ++ ")"

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -601,7 +601,9 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
               _ ->
                 "case let ."
                   ++ swiftCaseLabel enumCaseName
-                  ++ ":"
+                  ++ "("
+                  ++ (intercalate ", " (enumCaseFields <&> \(Field {..}) -> fieldName))
+                  ++ "):"
                   ++ indent
                     ( "try container.encode(\""
                         ++ enumCaseName

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -13,6 +13,7 @@ import Data.Functor ((<&>))
 import Data.List (intercalate, nub)
 import qualified Data.Map as Map
 import Data.Maybe (catMaybes, fromMaybe)
+import qualified Data.Set as Set
 import Moat.Pretty.Doc.DocC
 import Moat.Types
 
@@ -196,13 +197,103 @@ prettyTagDisambiguator disambiguate indents parent =
 -- | Lowercase the first character of an enum case name to produce an
 --   idiomatic Swift case label. This only affects the Swift identifier; the
 --   tag encoded to and decoded from the wire is left untouched.
+swiftCaseLowerFirst :: String -> String
+swiftCaseLowerFirst "" = ""
+swiftCaseLowerFirst (c : cs) = toLower c : cs
+
+-- | Produce the Swift identifier for an enum case: lowercase the first
+--   character and escape it with backticks if it collides with a keyword.
 swiftCaseLabel :: String -> String
-swiftCaseLabel "" = ""
-swiftCaseLabel (c : cs) = toLower c : cs
+swiftCaseLabel = escapeKeyword . swiftCaseLowerFirst
+
+-- | Swift reserved keywords, which can't be used as identifiers unless escaped
+--   with backticks. Taken from the "Keywords and Punctuation" section of /The
+--   Swift Programming Language/: the keywords used in declarations, statements,
+--   expressions and types, and patterns.
+--
+--   Deliberately omitted:
+--
+--   * Keywords reserved in particular contexts (e.g. @get@, @set@, @final@,
+--     @some@): these are valid as identifiers without escaping.
+--   * Keywords beginning with a number sign (e.g. @#available@): these can't
+--     form identifiers in the first place.
+swiftKeywords :: Set.Set String
+swiftKeywords =
+  Set.fromList
+    [ -- Keywords used in declarations
+      "associatedtype"
+    , "borrowing"
+    , "class"
+    , "consuming"
+    , "deinit"
+    , "enum"
+    , "extension"
+    , "fileprivate"
+    , "func"
+    , "import"
+    , "init"
+    , "inout"
+    , "internal"
+    , "let"
+    , "nonisolated"
+    , "open"
+    , "operator"
+    , "precedencegroup"
+    , "private"
+    , "protocol"
+    , "public"
+    , "rethrows"
+    , "static"
+    , "struct"
+    , "subscript"
+    , "typealias"
+    , "var"
+    , -- Keywords used in statements
+      "break"
+    , "case"
+    , "catch"
+    , "continue"
+    , "default"
+    , "defer"
+    , "do"
+    , "else"
+    , "fallthrough"
+    , "for"
+    , "guard"
+    , "if"
+    , "in"
+    , "repeat"
+    , "return"
+    , "switch"
+    , "throw"
+    , "where"
+    , "while"
+    , -- Keywords used in expressions and types
+      "Any"
+    , "as"
+    , "await"
+    , "false"
+    , "is"
+    , "nil"
+    , "self"
+    , "Self"
+    , "super"
+    , "throws"
+    , "true"
+    , "try"
+    ]
+
+-- | Escape an identifier with backticks if it collides with a Swift keyword,
+--   so that it can be used as a Swift identifier (e.g. a field name or enum
+--   case label).
+escapeKeyword :: String -> String
+escapeKeyword ident
+  | ident `Set.member` swiftKeywords = "`" ++ ident ++ "`"
+  | otherwise = ident
 
 labelCase :: Field -> String
 labelCase (Field "" ty _) = prettyMoatType ty
-labelCase (Field label ty _) = "_ " ++ label ++ ": " ++ prettyMoatType ty
+labelCase (Field label ty _) = "_ " ++ escapeKeyword label ++ ": " ++ prettyMoatType ty
 
 -- | Pretty-print a 'Ty'.
 prettyMoatType :: MoatType -> String
@@ -277,7 +368,7 @@ prettyEnumCases indents rawValue unknown cases = go cases ++ unknownCase
     -- values are left implicit for now.
     rawValueAssignment :: String -> String
     rawValueAssignment caseNm = case rawValue of
-      Just Str | swiftCaseLabel caseNm /= caseNm -> " = \"" ++ caseNm ++ "\""
+      Just Str | swiftCaseLowerFirst caseNm /= caseNm -> " = \"" ++ caseNm ++ "\""
       _ -> ""
 
     go = \case
@@ -310,7 +401,7 @@ prettyStructFields indents fields deprecatedFields = go fields
     deprecatedFieldsMap = Map.fromList deprecatedFields
     prettyField (Field fieldName fieldType _fieldDoc) =
       "public var "
-        ++ fieldName
+        ++ escapeKeyword fieldName
         ++ ": "
         ++ prettyMoatType fieldType
         ++ "\n"
@@ -353,17 +444,17 @@ prettyStructInitializer indents fields deprecatedFields =
 
     prettyParam :: Field -> String
     prettyParam (Field fieldName fieldType _) =
-      fieldName ++ ": " ++ prettyMoatType fieldType ++ (if isOptional fieldType then " = nil" else "")
+      escapeKeyword fieldName ++ ": " ++ prettyMoatType fieldType ++ (if isOptional fieldType then " = nil" else "")
 
     prettyAssignment :: String -> Field -> String
     prettyAssignment indentStr (Field fieldName _ _) =
-      indentStr ++ "    self." ++ fieldName ++ " = " ++ fieldName ++ "\n"
+      indentStr ++ "    self." ++ escapeKeyword fieldName ++ " = " ++ escapeKeyword fieldName ++ "\n"
 
 prettyNewtypeField :: String -> Field -> String -> String
 prettyNewtypeField indents (Field alias fieldType _) fieldName =
   indents
     ++ "public let "
-    ++ alias
+    ++ escapeKeyword alias
     ++ ": "
     ++ fieldName
     ++ "Tag"
@@ -422,7 +513,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
        in "case "
             ++ tagFieldName
             ++ "\n"
-            ++ intercalate "\n" (map ("case " ++) names)
+            ++ intercalate "\n" (map (("case " ++) . escapeKeyword) names)
 
     prettyInit :: String
     prettyInit =
@@ -517,7 +608,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                                 "try container.decode("
                                   ++ prettyMoatType fieldType
                                   ++ ".self, forKey: ."
-                                  ++ fieldName
+                                  ++ escapeKeyword fieldName
                                   ++ ")"
                             )
                         )
@@ -635,7 +726,7 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                 "case let ."
                   ++ swiftCaseLabel enumCaseName
                   ++ "("
-                  ++ (intercalate ", " (enumCaseFields <&> \(Field {..}) -> fieldName))
+                  ++ (intercalate ", " (enumCaseFields <&> \(Field {..}) -> escapeKeyword fieldName))
                   ++ "):"
                   ++ indent
                     ( "try container.encode(\""
@@ -647,9 +738,9 @@ prettyEnumCoding indents parentName cases unknownCase SumOfProductEncodingOption
                           "\n"
                           ( enumCaseFields <&> \(Field {..}) ->
                               "try container.encode("
-                                ++ fieldName
+                                ++ escapeKeyword fieldName
                                 ++ ", forKey: ."
-                                ++ fieldName
+                                ++ escapeKeyword fieldName
                                 ++ ")"
                           )
                     )

--- a/src/Moat/Pretty/Swift.hs
+++ b/src/Moat/Pretty/Swift.hs
@@ -12,7 +12,7 @@ import Data.Char (toLower)
 import Data.Functor ((<&>))
 import Data.List (intercalate, nub)
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Moat.Pretty.Doc.DocC
 import Moat.Types
 
@@ -34,19 +34,21 @@ prettySwiftDataWith ::
   String
 prettySwiftDataWith indent = \case
   MoatEnum {..} ->
-    prettyTypeDoc "" enumDoc []
-      ++ "public enum "
-      ++ prettyMoatTypeHeader enumName (addTyVarBounds enumTyVars enumProtocols)
-      ++ prettyRawValueAndProtocols enumRawValue enumProtocols
-      ++ " {"
-      ++ newlineNonEmpty enumCases
-      ++ prettyEnumCases indents enumEnumUnknownCase enumCases
-      ++ newlineNonEmpty enumPrivateTypes
-      ++ prettyPrivateTypes indents enumPrivateTypes
-      ++ prettyTags indents enumTags
-      ++ newlineNonEmpty enumTags
-      ++ prettyEnumCoding indents enumName enumCases enumEnumUnknownCase enumSumOfProductEncodingOption
-      ++ "}"
+    let (rawValue, protocols) =
+          enforcedEnumRawValueAndProtocols enumCases enumRawValue enumProtocols
+     in prettyTypeDoc "" enumDoc []
+          ++ "public enum "
+          ++ prettyMoatTypeHeader enumName (addTyVarBounds enumTyVars protocols)
+          ++ prettyRawValueAndProtocols rawValue protocols
+          ++ " {"
+          ++ newlineNonEmpty enumCases
+          ++ prettyEnumCases indents rawValue enumEnumUnknownCase enumCases
+          ++ newlineNonEmpty enumPrivateTypes
+          ++ prettyPrivateTypes indents enumPrivateTypes
+          ++ prettyTags indents enumTags
+          ++ newlineNonEmpty enumTags
+          ++ prettyEnumCoding indents enumName enumCases enumEnumUnknownCase enumSumOfProductEncodingOption
+          ++ "}"
   MoatStruct {..} ->
     prettyTypeDoc "" structDoc []
       ++ "public struct "
@@ -112,6 +114,27 @@ prettyTypeDoc indents doc fields =
 prettyMoatTypeHeader :: String -> [String] -> String
 prettyMoatTypeHeader name [] = name
 prettyMoatTypeHeader name tyVars = name ++ "<" ++ intercalate ", " tyVars ++ ">"
+
+-- | For a plain (C-style) enum — one where every case is fieldless — enforce a
+--   raw value and 'Codable' conformance. Swift synthesizes a verbose
+--   keyed-object @Codable@ representation for raw-value-less enums (e.g.
+--   @{"north": {}}@), so we pin a scalar raw value instead, which round-trips
+--   as the bare tag (e.g. @"north"@).
+--
+--   An explicitly-supplied integer raw value is respected as-is; any other (or
+--   absent) raw value defaults to 'Str'. 'Codable' is appended unless the user
+--   already requested it.
+--
+--   Enums with associated values are returned unchanged: they cannot carry a
+--   raw value and rely on the custom coding emitted by 'prettyEnumCoding'.
+enforcedEnumRawValueAndProtocols ::
+  [EnumCase] -> Maybe MoatType -> [Protocol] -> (Maybe MoatType, [Protocol])
+enforcedEnumRawValueAndProtocols cases rawValue protocols
+  | isCEnum cases =
+      ( Just (fromMaybe Str rawValue)
+      , protocols ++ [Codable | Codable `notElem` protocols]
+      )
+  | otherwise = (rawValue, protocols)
 
 prettyRawValueAndProtocols :: Maybe MoatType -> [Protocol] -> String
 prettyRawValueAndProtocols Nothing [] = ""
@@ -245,9 +268,18 @@ prettyApp t1 t2 =
       (args, ret) -> (e1 : args, ret)
     go e1 e2 = ([e1], e2)
 
-prettyEnumCases :: String -> Maybe String -> [EnumCase] -> String
-prettyEnumCases indents unknown cases = go cases ++ unknownCase
+prettyEnumCases :: String -> Maybe MoatType -> Maybe String -> [EnumCase] -> String
+prettyEnumCases indents rawValue unknown cases = go cases ++ unknownCase
   where
+    -- For a 'Str' raw value, pin the raw value to the original case name
+    -- whenever it differs from the lowercased Swift label, so the wire tag is
+    -- preserved (e.g. @case aliceInChains = "AliceInChains"@). Integer raw
+    -- values are left implicit for now.
+    rawValueAssignment :: String -> String
+    rawValueAssignment caseNm = case rawValue of
+      Just Str | swiftCaseLabel caseNm /= caseNm -> " = \"" ++ caseNm ++ "\""
+      _ -> ""
+
     go = \case
       [] -> ""
       (EnumCase caseNm caseDoc [] : xs) ->
@@ -255,6 +287,7 @@ prettyEnumCases indents unknown cases = go cases ++ unknownCase
           ++ indents
           ++ "case "
           ++ swiftCaseLabel caseNm
+          ++ rawValueAssignment caseNm
           ++ "\n"
           ++ go xs
       (EnumCase caseNm caseDoc cs : xs) ->

--- a/test/DuplicateRecordFieldSpec.hs
+++ b/test/DuplicateRecordFieldSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-
 {- HLINT ignore "Avoid restricted extensions" -}
 {-# LANGUAGE DuplicateRecordFields #-}
 

--- a/test/DuplicateRecordFieldSpec.hs
+++ b/test/DuplicateRecordFieldSpec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {- HLINT ignore "Avoid restricted extensions" -}
 {-# LANGUAGE DuplicateRecordFields #-}
 
@@ -28,16 +30,26 @@ data Data1 = Data1
 mobileGen ''Data0
 mobileGen ''Data1
 
+-- | GHC 9.10 (template-haskell 2.22) fixed 'getDoc' for fields whose names are
+--   made ambiguous by DuplicateRecordFields (GHC #17551). Earlier versions drop
+--   the documentation for the duplicated field, producing different golden
+--   output, so we key the golden files on the template-haskell version.
+goldenName :: String -> String
+#if MIN_VERSION_template_haskell(2,22,0)
+goldenName prefix = prefix <> "DuplicateRecordFieldSpec"
+#else
+goldenName prefix = prefix <> "DuplicateRecordFieldSpecNoFieldDoc"
+#endif
+
 spec :: Spec
 spec =
   when hasDoc $ do
     describe "stays golden" $ do
-      let moduleName = "DuplicateRecordFieldSpec"
       it "swift" $
-        defaultGolden ("swiftRecord0" <> moduleName) (showSwift @Data0)
+        defaultGolden (goldenName "swiftRecord0") (showSwift @Data0)
       it "swift" $
-        defaultGolden ("swiftRecord1" <> moduleName) (showSwift @Data1)
+        defaultGolden (goldenName "swiftRecord1") (showSwift @Data1)
       it "kotlin" $
-        defaultGolden ("kotlinRecord0" <> moduleName) (showKotlin @Data0)
+        defaultGolden (goldenName "kotlinRecord0") (showKotlin @Data0)
       it "kotlin" $
-        defaultGolden ("kotlinRecord1" <> moduleName) (showKotlin @Data1)
+        defaultGolden (goldenName "kotlinRecord1") (showKotlin @Data1)

--- a/test/EnumUpperCaseLabelsSpec.hs
+++ b/test/EnumUpperCaseLabelsSpec.hs
@@ -1,0 +1,29 @@
+module EnumUpperCaseLabelsSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Enum
+  = AliceInChains
+  | BlindMelon
+  | Candlebox
+
+mobileGenWith
+  ( defaultOptions
+      { constructorLowerFirst = False
+      , dataRawValue = Just Str
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "EnumUpperCaseLabelsSpec"
+    it "swift" $
+      defaultGolden ("swift" <> moduleName) (showSwift @Enum)
+    it "kotlin" $
+      defaultGolden ("kotlin" <> moduleName) (showKotlin @Enum)

--- a/test/EscapedKeywordsSpec.hs
+++ b/test/EscapedKeywordsSpec.hs
@@ -1,0 +1,45 @@
+module EscapedKeywordsSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+
+data Struct = Struct
+  { func :: Int
+  , static :: String
+  , public :: Bool
+  }
+
+mobileGenWith
+  (defaultOptions {dataProtocols = [Codable]})
+  ''Struct
+
+data Keyword
+  = Case
+  | Default
+  | Class
+  | Switch
+  | Return
+
+mobileGen
+  ''Keyword
+
+data Expression
+  = Try {defer :: Int, fallthrough :: String}
+  | Catch
+
+mobileGenWith
+  (defaultOptions {dataProtocols = [Codable]})
+  ''Expression
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "EscapedKeywordsSpec"
+    it "swift struct" $
+      defaultGolden ("swiftStruct" <> moduleName) (showSwift @Struct)
+    it "swift plain enum" $
+      defaultGolden ("swiftKeyword" <> moduleName) (showSwift @Keyword)
+    it "swift sum of products" $
+      defaultGolden ("swiftExpression" <> moduleName) (showSwift @Expression)

--- a/test/SumOfProductWithUpperCaseTagsSpec.hs
+++ b/test/SumOfProductWithUpperCaseTagsSpec.hs
@@ -1,0 +1,42 @@
+module SumOfProductWithUpperCaseTagsSpec where
+
+import Common
+import Moat
+import Test.Hspec
+import Test.Hspec.Golden
+import Prelude hiding (Enum)
+
+data Record1 = Record1
+  { field :: Int }
+
+data Enum
+  = DataCons0
+  | DataCons1 Record1
+
+mobileGen ''Record1
+
+mobileGenWith
+  ( defaultOptions
+      { constructorLowerFirst = False
+      , dataAnnotations = [Parcelize, Serializable, SerialName]
+      , dataInterfaces = [Parcelable]
+      , dataProtocols = [Hashable, Codable]
+      , sumOfProductEncodingOptions =
+          SumOfProductEncodingOptions
+            { encodingStyle = TaggedObjectStyle
+            , sumAnnotations = [RawAnnotation "JsonClassDiscriminator(\"tag\")"]
+            , tagFieldName = "tag"
+            , contentsFieldName = "contents"
+            }
+      }
+  )
+  ''Enum
+
+spec :: Spec
+spec =
+  describe "stays golden" $ do
+    let moduleName = "SumOfProductWithUpperCaseTagsSpec"
+    it "swift" $
+      defaultGolden ("swiftEnum" <> moduleName) (showSwift @Enum)
+    it "kotlin" $
+      defaultGolden ("kotlinEnum" <> moduleName) (showKotlin @Enum)

--- a/test/SumOfProductWithUpperCaseTagsSpec.hs
+++ b/test/SumOfProductWithUpperCaseTagsSpec.hs
@@ -7,7 +7,7 @@ import Test.Hspec.Golden
 import Prelude hiding (Enum)
 
 data Record1 = Record1
-  { field :: Int }
+  {field :: Int}
 
 data Enum
   = DataCons0


### PR DESCRIPTION
Currently, the Swift backend emits enum cases verbatim to match the constructor name in Haskell. It's a fairly strong idiom for these to be lowercased, so when Moat is configured to preserve the Haskell name (via `constructorLowerFirst = False`), it is possible for Moat to generate undesirable code.

There's a bunch of housekeeping in the first two commits; I can separate these if needed.